### PR TITLE
Generate .gitignore when creating a project

### DIFF
--- a/src/create/create_project.rs
+++ b/src/create/create_project.rs
@@ -64,6 +64,16 @@ impl LazyJava {
             .map_err(CreateProjectError::CreateFileError)?;
         }
 
+        let mut gitignore = project_dir.clone();
+        gitignore.push(".gitignore");
+        if gitignore.exists() {
+            log::info!(".gitignore already exists, skipping");
+        } else {
+            fs::write(&gitignore, GITIGNORE_CONTENTS)
+                .map_err(CreateProjectError::CreateFileError)?;
+            log::debug!("Created .gitignore");
+        }
+
         if git {
             log::debug!("Initializing git repository");
             let status = git_init(&project_dir).map_err(CreateProjectError::NoInit)?;
@@ -106,6 +116,17 @@ pub enum CreateProjectError {
     #[error("Couldnt run git init, {0}")]
     NoInit(io::Error),
 }
+
+const GITIGNORE_CONTENTS: &str = r#"build/
+lib/
+*.class
+*.jar
+*.log
+.idea/
+.vscode/
+*.iml
+.DS_Store
+"#;
 
 fn example_class(name: &str) -> String {
     format!(


### PR DESCRIPTION
## Summary

When running `lazy-java create`, automatically generate a `.gitignore` file with sensible Java defaults.

## Changes

- `src/create/create_project.rs` — after creating project directories, writes a `.gitignore` to the project root
- If `.gitignore` already exists, skips with an info log instead of overwriting
- Generated `.gitignore` includes:
  - `build/` and `lib/` (build artifacts and downloaded JARs)
  - `*.class` and `*.jar` (compiled class files)
  - `*.log`
  - `.idea/`, `.vscode/`, `*.iml` (IDE directories)
  - `.DS_Store` (macOS metadata)
- `.gitignore` is generated regardless of `--bare` flag (only the example `Main.java` is skipped by `--bare`)

Closes #29