### PR TITLE
added gitignore creating to projects

### DIFF
--- a/src/create/create_project.rs
+++ b/src/create/create_project.rs
@@ -64,16 +64,6 @@ impl LazyJava {
             .map_err(CreateProjectError::CreateFileError)?;
         }
 
-        let mut gitignore = project_dir.clone();
-        gitignore.push(".gitignore");
-        if gitignore.exists() {
-            log::info!(".gitignore already exists, skipping");
-        } else {
-            fs::write(&gitignore, GITIGNORE_CONTENTS)
-                .map_err(CreateProjectError::CreateFileError)?;
-            log::debug!("Created .gitignore");
-        }
-
         if git {
             log::debug!("Initializing git repository");
             let status = git_init(&project_dir).map_err(CreateProjectError::NoInit)?;
@@ -116,17 +106,6 @@ pub enum CreateProjectError {
     #[error("Couldnt run git init, {0}")]
     NoInit(io::Error),
 }
-
-const GITIGNORE_CONTENTS: &str = r#"build/
-lib/
-*.class
-*.jar
-*.log
-.idea/
-.vscode/
-*.iml
-.DS_Store
-"#;
 
 fn example_class(name: &str) -> String {
     format!(

--- a/src/create/init_git.rs
+++ b/src/create/init_git.rs
@@ -1,5 +1,5 @@
 use std::{
-    env, io,
+    env, fs, io,
     path::Path,
     process::{Command, ExitStatus},
 };
@@ -23,6 +23,14 @@ pub fn git_init(project_path: &Path) -> Result<ExitStatus, io::Error> {
     let output = git_command()?;
     env::set_current_dir(&current_path)?;
 
+    let gitignore = project_path.join(".gitignore");
+    if gitignore.exists() {
+        log::info!(".gitignore already exists, skipping");
+    } else {
+        fs::write(&gitignore, GITIGNORE_CONTENTS)?;
+        log::debug!("Created .gitignore");
+    }
+
     if output.success() {
         log::debug!("Git initialization successful");
     } else {
@@ -31,3 +39,14 @@ pub fn git_init(project_path: &Path) -> Result<ExitStatus, io::Error> {
 
     Ok(output)
 }
+const GITIGNORE_CONTENTS: &str = r#"build/
+lib/
+*.class
+*.jar
+*.log
+.env
+.idea/
+.vscode/
+*.iml
+.DS_Store
+"#;


### PR DESCRIPTION
## Summary

When running `lazy-java create`, automatically generate a `.gitignore` file with sensible Java defaults.

## Changes

- `src/create/create_project.rs` — after creating project directories, writes a `.gitignore` to the project root
- If `.gitignore` already exists, skips with an info log instead of overwriting
- Generated `.gitignore` includes:
  - `build/` and `lib/` (build artifacts and downloaded JARs)
  - `*.class` and `*.jar` (compiled class files)
  - `*.log`
  - `.idea/`, `.vscode/`, `*.iml` (IDE directories)
  - `.DS_Store` (macOS metadata)
- `.gitignore` is generated regardless of `--bare` flag (only the example `Main.java` is skipped by `--bare`)

Closes #29