### PR TITLE
Introduce shared Context to eliminate prop drilling of project state

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -1,7 +1,5 @@
 use clap::{Parser, Subcommand};
 
-use crate::{BUILD_FOLDER, LIB_FOLDER, SRC_FOLDER};
-
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
 #[command(propagate_version = true)]
@@ -161,14 +159,14 @@ pub struct LazyJavaGlobalArgs {
     pub verbose: u8,
 
     /// Where to find the java files to compile
-    #[arg(long = "source", default_value_t = SRC_FOLDER.to_string(), global = true)]
-    pub source: String,
+    #[arg(long = "source", global = true)]
+    pub source: Option<String>,
 
     /// Where to save the compiled java files
-    #[arg(long = "bin", default_value_t = BUILD_FOLDER.to_string(), global = true)]
-    pub build: String,
+    #[arg(long = "bin", global = true)]
+    pub build: Option<String>,
 
     /// Where to look for extra packages
-    #[arg(long = "lib",  default_value_t = LIB_FOLDER.to_string(), global = true)]
-    pub lib: String,
+    #[arg(long = "lib", global = true)]
+    pub lib: Option<String>,
 }

--- a/src/build/build_java.rs
+++ b/src/build/build_java.rs
@@ -1,3 +1,4 @@
+use crate::Context;
 use crate::args::{BuildArgs, BuildCommand, BuildSubCommand};
 use crate::build::find_stale_files::{files_to_recompile, find_modified_files};
 use crate::dependancy_graph::graph::DependancyGraph;
@@ -8,37 +9,35 @@ use crate::lsp::classpath::Classpath;
 use crate::utils::processes::{compile_java, compile_java_files};
 
 impl LazyJava {
-    pub fn build(&self, args: &BuildCommand) -> Result<(), LazyJavaError> {
-        self.assert_build_lib_src()?;
-
+    pub fn build(args: &BuildCommand, ctx: &Context) -> Result<(), LazyJavaError> {
         if let Some(build_command) = &args.command {
             match build_command {
-                BuildSubCommand::Modified {} => self.show_modified_files(),
-                BuildSubCommand::Dependancies {} => self.show_dependancy_graph(),
-                BuildSubCommand::Dependants {} => self.show_depentants_graph(),
-                BuildSubCommand::Stale {} => self.show_rebuild_files(),
-                BuildSubCommand::Classpath {} => self.rebuild_classpath(),
+                BuildSubCommand::Modified {} => Self::show_modified_files(ctx),
+                BuildSubCommand::Dependancies {} => Self::show_dependancy_graph(ctx),
+                BuildSubCommand::Dependants {} => Self::show_depentants_graph(ctx),
+                BuildSubCommand::Stale {} => Self::show_rebuild_files(ctx),
+                BuildSubCommand::Classpath {} => Self::rebuild_classpath(ctx),
             }
         } else {
-            self.build_java(&args.args)
+            Self::build_java(&args.args, ctx)
         }
     }
-    pub fn build_java(&self, args: &BuildArgs) -> Result<(), LazyJavaError> {
+    pub fn build_java(args: &BuildArgs, ctx: &Context) -> Result<(), LazyJavaError> {
         if args.build_all {
-            self.rebuild(args)
+            Self::rebuild(args, ctx)
         } else {
-            self.incrimental_build(args)
+            Self::incrimental_build(args, ctx)
         }
     }
-    fn incrimental_build(&self, args: &BuildArgs) -> Result<(), LazyJavaError> {
+    fn incrimental_build(args: &BuildArgs, ctx: &Context) -> Result<(), LazyJavaError> {
         log::info!("Starting incremental build");
-        Classpath::generate_if_stale(self)?;
+        Classpath::generate_if_stale(ctx)?;
 
-        let graph = DependancyGraph::create(&self.src)?;
+        let graph = DependancyGraph::create(&ctx.src)?;
         log::debug!("Created dependency graph");
 
-        let modified_files = find_modified_files(&self.build, &self.src)
-            .map_err(LazyJavaError::NoStaleFilesError)?;
+        let modified_files =
+            find_modified_files(&ctx.bin, &ctx.src).map_err(LazyJavaError::NoStaleFilesError)?;
 
         if modified_files.is_empty() {
             log::info!("No modified files, skipping compilation");
@@ -49,7 +48,7 @@ impl LazyJava {
         let recompile = files_to_recompile(graph, modified_files)?;
         log::debug!("Need to recompile {} files", recompile.len());
 
-        let status = compile_java_files(&self.build, &self.lib, &args.javac_args, recompile)
+        let status = compile_java_files(&ctx.bin, &ctx.lib, &args.javac_args, recompile)
             .map_err(LazyJavaError::UnableToCompile)?;
 
         log::debug!("Java compilation completed");
@@ -57,7 +56,7 @@ impl LazyJava {
             log::info!("Compilation successful");
 
             let file_time = filetime::FileTime::now();
-            filetime::set_file_mtime(&self.build, file_time)
+            filetime::set_file_mtime(&ctx.bin, file_time)
                 .map_err(LazyJavaError::NoBuildModificationTime)?;
 
             Ok(())
@@ -67,11 +66,11 @@ impl LazyJava {
         }
     }
 
-    fn rebuild(&self, args: &BuildArgs) -> Result<(), LazyJavaError> {
+    fn rebuild(args: &BuildArgs, ctx: &Context) -> Result<(), LazyJavaError> {
         log::info!("Starting full rebuild");
-        Classpath::generate(self)?;
+        Classpath::generate(ctx)?;
 
-        let status = compile_java(&self.src, &self.build, &self.lib, &args.javac_args)
+        let status = compile_java(&ctx.src, &ctx.bin, &ctx.lib, &args.javac_args)
             .map_err(LazyJavaError::UnableToCompile)?;
         log::debug!("Java compilation completed");
 
@@ -79,7 +78,7 @@ impl LazyJava {
             log::info!("Build successful");
 
             let file_time = filetime::FileTime::now();
-            filetime::set_file_mtime(&self.build, file_time)
+            filetime::set_file_mtime(&ctx.bin, file_time)
                 .map_err(LazyJavaError::NoBuildModificationTime)?;
 
             Ok(())
@@ -88,9 +87,9 @@ impl LazyJava {
             Err(LazyJavaError::CompilationErrors)
         }
     }
-    fn show_dependancy_graph(&self) -> Result<(), LazyJavaError> {
+    fn show_dependancy_graph(ctx: &Context) -> Result<(), LazyJavaError> {
         log::info!("Displaying dependency graph");
-        let graph = DependancyGraph::create(&self.src)?;
+        let graph = DependancyGraph::create(&ctx.src)?;
 
         for (_key, entry) in graph.nodes.iter() {
             println!(" {}", entry.file_name,);
@@ -101,10 +100,10 @@ impl LazyJava {
         }
         Ok(())
     }
-    fn show_modified_files(&self) -> Result<(), LazyJavaError> {
+    fn show_modified_files(ctx: &Context) -> Result<(), LazyJavaError> {
         log::info!("Displaying modified files");
-        let stale_files = find_modified_files(&self.build, &self.src)
-            .map_err(LazyJavaError::NoStaleFilesError)?;
+        let stale_files =
+            find_modified_files(&ctx.bin, &ctx.src).map_err(LazyJavaError::NoStaleFilesError)?;
 
         for file in stale_files {
             println!("{}", file.to_string_lossy());
@@ -112,12 +111,12 @@ impl LazyJava {
 
         Ok(())
     }
-    fn show_rebuild_files(&self) -> Result<(), LazyJavaError> {
+    fn show_rebuild_files(ctx: &Context) -> Result<(), LazyJavaError> {
         log::info!("Displaying files to rebuild");
-        let graph = DependancyGraph::create(&self.src)?;
+        let graph = DependancyGraph::create(&ctx.src)?;
 
-        let stale_files = find_modified_files(&self.build, &self.src)
-            .map_err(LazyJavaError::NoStaleFilesError)?;
+        let stale_files =
+            find_modified_files(&ctx.bin, &ctx.src).map_err(LazyJavaError::NoStaleFilesError)?;
 
         let recompile = files_to_recompile(graph, stale_files)?;
 
@@ -127,9 +126,9 @@ impl LazyJava {
 
         Ok(())
     }
-    fn show_depentants_graph(&self) -> Result<(), LazyJavaError> {
+    fn show_depentants_graph(ctx: &Context) -> Result<(), LazyJavaError> {
         log::info!("Displaying dependants graph");
-        let graph = DependancyGraph::create(&self.src)?;
+        let graph = DependancyGraph::create(&ctx.src)?;
         for (_key, entry) in graph.nodes.iter() {
             println!(" {}", entry.file_name,);
             for dep in &entry.dependants {
@@ -140,7 +139,7 @@ impl LazyJava {
 
         Ok(())
     }
-    fn rebuild_classpath(&self) -> Result<(), LazyJavaError> {
-        Ok(Classpath::generate(self)?)
+    fn rebuild_classpath(ctx: &Context) -> Result<(), LazyJavaError> {
+        Ok(Classpath::generate(ctx)?)
     }
 }

--- a/src/clean/clean.rs
+++ b/src/clean/clean.rs
@@ -1,22 +1,21 @@
 use std::fs;
 
-use crate::{lazy_java::LazyJava, lazy_java_error::LazyJavaError};
+use crate::{Context, lazy_java::LazyJava, lazy_java_error::LazyJavaError};
 
 impl LazyJava {
-    pub fn clean(&self) -> Result<(), LazyJavaError> {
-        self.assert_build_lib_src()?;
+    pub fn clean(ctx: &Context) -> Result<(), LazyJavaError> {
         log::info!("Starting clean operation");
 
-        let classpath = &self.root.join(".classpath");
+        let classpath = ctx.root.join(".classpath");
 
         let _ = fs::remove_file(classpath);
         log::debug!("Removed .classpath file");
 
-        fs::remove_dir_all(&self.build).map_err(LazyJavaError::NoRemoveBuild)?;
-        log::debug!("Removed build directory: {:?}", self.build);
+        fs::remove_dir_all(&ctx.bin).map_err(LazyJavaError::NoRemoveBuild)?;
+        log::debug!("Removed build directory: {:?}", ctx.bin);
 
-        fs::create_dir(&self.build).map_err(LazyJavaError::NoCreateBuild)?;
-        log::debug!("Created new build directory: {:?}", self.build);
+        fs::create_dir(&ctx.bin).map_err(LazyJavaError::NoCreateBuild)?;
+        log::debug!("Created new build directory: {:?}", ctx.bin);
 
         log::info!("Clean operation completed successfully");
         Ok(())

--- a/src/config/config_structs.rs
+++ b/src/config/config_structs.rs
@@ -15,6 +15,7 @@ pub struct Config {
     pub dependancies: Vec<ConfigDependancy>,
 }
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct ConfigProject {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -30,6 +31,7 @@ pub struct ConfigProject {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct ConfigSetup {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lib: Option<String>,
@@ -41,7 +43,7 @@ pub struct ConfigSetup {
     pub bin: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct ConfigDependancy {
     pub id: MavenIdBuf,
 }

--- a/src/config/config_structs.rs
+++ b/src/config/config_structs.rs
@@ -8,6 +8,9 @@ pub struct Config {
     pub project: ConfigProject,
 
     #[serde(default)]
+    pub setup: ConfigSetup,
+
+    #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub dependancies: Vec<ConfigDependancy>,
 }
@@ -24,6 +27,18 @@ pub struct ConfigProject {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ConfigSetup {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lib: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub src: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bin: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/context.rs
+++ b/src/context.rs
@@ -61,25 +61,37 @@ impl Context {
             config,
         };
 
-        ctx.assert_build_lib_src()?;
-
         Ok(ctx)
     }
 
-    pub fn assert_build_lib_src(&self) -> Result<(), LazyJavaError> {
+    pub fn assert_src_exists(&self) -> Result<(), LazyJavaError> {
         if !self.src.exists() {
             let path = path::absolute(self.src.clone()).unwrap();
             return Err(LazyJavaError::NoSource(path.to_string_lossy().into()));
         }
+        Ok(())
+    }
 
+    pub fn assert_bin_exists(&self) -> Result<(), LazyJavaError> {
         if !self.bin.exists() {
             let path = path::absolute(self.bin.clone()).unwrap();
             return Err(LazyJavaError::NoBuild(path.to_string_lossy().into()));
         }
+        Ok(())
+    }
+
+    pub fn assert_lib_exists(&self) -> Result<(), LazyJavaError> {
         if !self.lib.exists() {
             let path = path::absolute(self.lib.clone()).unwrap();
             return Err(LazyJavaError::NoLib(path.to_string_lossy().into()));
         }
+        Ok(())
+    }
+
+    pub fn assert_build_lib_src(&self) -> Result<(), LazyJavaError> {
+        self.assert_src_exists()?;
+        self.assert_bin_exists()?;
+        self.assert_lib_exists()?;
         Ok(())
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,114 @@
+use std::{
+    env,
+    path::{self, PathBuf},
+};
+
+use crate::{
+    BUILD_FOLDER, LIB_FOLDER, SRC_FOLDER, args::LazyJavaArgs, config::Config,
+    lazy_java_error::LazyJavaError, utils::find_root::find_root,
+};
+
+pub struct Context {
+    pub src: PathBuf,
+    pub bin: PathBuf,
+    pub lib: PathBuf,
+    pub root: PathBuf,
+    pub current: PathBuf,
+
+    pub relative_src: String,
+    pub relative_bin: String,
+    pub relative_lib: String,
+
+    pub config: Config,
+}
+impl Context {
+    pub fn new(args: &LazyJavaArgs) -> Result<Context, LazyJavaError> {
+        let current = env::current_dir().map_err(LazyJavaError::NoCurrentDir)?;
+        log::debug!("Current directory: {:?}", current);
+
+        let root = find_root(&current).map_err(|e| {
+            log::error!("Could not locate project root");
+            LazyJavaError::NoRoot(e)
+        })?;
+
+        let root = root.unwrap_or(env::current_dir().map_err(|e| LazyJavaError::NoRoot(e))?);
+
+        let config = Config::fetch(&root)?;
+
+        log::info!("Project root: {:?}", root);
+
+        let relative_src = Self::src_path(args, &config).to_string();
+        let relative_lib = Self::lib_path(args, &config).to_string();
+        let relative_bin = Self::bin_path(args, &config).to_string();
+
+        let lib = root.join(&relative_lib);
+        let src = root.join(&relative_src);
+        let bin = root.join(&relative_bin);
+
+        log::debug!("Source directory: {:?}", src);
+        log::debug!("Build directory: {:?}", bin);
+        log::debug!("Library directory: {:?}", lib);
+
+        let ctx = Context {
+            relative_bin,
+            relative_lib,
+            relative_src,
+            src,
+            bin,
+            lib,
+            root,
+            current,
+            config,
+        };
+
+        ctx.assert_build_lib_src()?;
+
+        Ok(ctx)
+    }
+
+    pub fn assert_build_lib_src(&self) -> Result<(), LazyJavaError> {
+        if !self.src.exists() {
+            let path = path::absolute(self.src.clone()).unwrap();
+            return Err(LazyJavaError::NoSource(path.to_string_lossy().into()));
+        }
+
+        if !self.bin.exists() {
+            let path = path::absolute(self.bin.clone()).unwrap();
+            return Err(LazyJavaError::NoBuild(path.to_string_lossy().into()));
+        }
+        if !self.lib.exists() {
+            let path = path::absolute(self.lib.clone()).unwrap();
+            return Err(LazyJavaError::NoLib(path.to_string_lossy().into()));
+        }
+        Ok(())
+    }
+
+    fn src_path<'a>(args: &'a LazyJavaArgs, config: &'a Config) -> &'a str {
+        if let Some(src) = &args.global_args.source {
+            return src;
+        } else if let Some(src) = &config.setup.src {
+            return src;
+        } else {
+            return SRC_FOLDER;
+        }
+    }
+
+    fn bin_path<'a>(args: &'a LazyJavaArgs, config: &'a Config) -> &'a str {
+        if let Some(bin) = &args.global_args.source {
+            return bin;
+        } else if let Some(bin) = &config.setup.src {
+            return bin;
+        } else {
+            return BUILD_FOLDER;
+        }
+    }
+    fn lib_path<'a>(args: &'a LazyJavaArgs, config: &'a Config) -> &'a str {
+        if let Some(lib) = &args.global_args.source {
+            return lib;
+        } else if let Some(lib) = &config.setup.src {
+            return lib;
+        } else {
+            return LIB_FOLDER;
+        }
+    }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -94,18 +94,18 @@ impl Context {
     }
 
     fn bin_path<'a>(args: &'a LazyJavaArgs, config: &'a Config) -> &'a str {
-        if let Some(bin) = &args.global_args.source {
+        if let Some(bin) = &args.global_args.build {
             return bin;
-        } else if let Some(bin) = &config.setup.src {
+        } else if let Some(bin) = &config.setup.bin {
             return bin;
         } else {
             return BUILD_FOLDER;
         }
     }
     fn lib_path<'a>(args: &'a LazyJavaArgs, config: &'a Config) -> &'a str {
-        if let Some(lib) = &args.global_args.source {
+        if let Some(lib) = &args.global_args.lib {
             return lib;
-        } else if let Some(lib) = &config.setup.src {
+        } else if let Some(lib) = &config.setup.lib {
             return lib;
         } else {
             return LIB_FOLDER;

--- a/src/create/create_project.rs
+++ b/src/create/create_project.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 impl LazyJava {
-    pub fn create(&self, args: &CreateArgs) -> Result<(), LazyJavaError> {
+    pub fn create(args: &CreateArgs) -> Result<(), LazyJavaError> {
         log::info!("Starting create operation");
         let name = match &args.name {
             Some(name) => name.clone(),

--- a/src/find/find_java.rs
+++ b/src/find/find_java.rs
@@ -1,15 +1,13 @@
 use crate::{
-    args::FindArgs, lazy_java::LazyJava, lazy_java_error::LazyJavaError,
+    Context, args::FindArgs, lazy_java::LazyJava, lazy_java_error::LazyJavaError,
     utils::find_main::find_main_classes,
 };
 
 impl LazyJava {
-    pub fn find(&self, _args: &FindArgs) -> Result<(), LazyJavaError> {
-        self.assert_build_lib_src()?;
+    pub fn find(_args: &FindArgs, ctx: &Context) -> Result<(), LazyJavaError> {
         log::info!("Starting find operation");
 
-        let mains =
-            find_main_classes(&self.src).map_err(LazyJavaError::CouldntFindMains)?;
+        let mains = find_main_classes(&ctx.src).map_err(LazyJavaError::CouldntFindMains)?;
         log::debug!("Found {} main classes", mains.len());
 
         for main in mains {

--- a/src/lazy_java.rs
+++ b/src/lazy_java.rs
@@ -1,30 +1,65 @@
 use crate::{
     Context,
-    args::{LazyJavaArgs, LazyJavaCommand},
+    args::{
+        AddArgs, BuildCommand, FindArgs, LazyJavaArgs, LazyJavaCommand, RemoveArgs, RunArgs,
+        SyncArgs,
+    },
     lazy_java_error::LazyJavaError,
 };
 pub struct LazyJava;
 
 impl LazyJava {
-    pub fn execute(args: LazyJavaArgs) -> Result<(), LazyJavaError> {
-        // commands that do not require contexts go here
-        if let LazyJavaCommand::Create { args } = &args.command {
-            Self::create(args)?;
+    pub fn execute(cli_args: LazyJavaArgs) -> Result<(), LazyJavaError> {
+        match &cli_args.command {
+            LazyJavaCommand::Create { args } => Self::create(args),
+            LazyJavaCommand::Build { args } => Self::build_internal(&cli_args, args),
+            LazyJavaCommand::Clean {} => Self::clean_internal(&cli_args),
+            LazyJavaCommand::Find { args } => Self::find_internal(&cli_args, args),
+            LazyJavaCommand::Run { args } => Self::run_internal(&cli_args, args),
+            LazyJavaCommand::Add { args } => Self::add_internal(&cli_args, args),
+            LazyJavaCommand::Remove { args } => Self::remove_internal(&cli_args, args),
+            LazyJavaCommand::Sync { args } => Self::sync_internal(&cli_args, args),
         }
+    }
 
-        let mut context = Context::new(&args)?;
+    fn build_internal(all_args: &LazyJavaArgs, args: &BuildCommand) -> Result<(), LazyJavaError> {
+        let ctx = Context::new(all_args)?;
+        ctx.assert_build_lib_src()?;
+        Self::build(args, &ctx)
+    }
 
-        // commands that require contexts go here
-        match &args.command {
-            LazyJavaCommand::Run { args } => Self::run(args, &context)?,
-            LazyJavaCommand::Build { args } => Self::build(args, &context)?,
-            LazyJavaCommand::Clean {} => Self::clean(&context)?,
-            LazyJavaCommand::Find { args } => Self::find(args, &context)?,
-            LazyJavaCommand::Add { args } => Self::add(args, &mut context)?,
-            LazyJavaCommand::Remove { args } => Self::remove(args, &mut context)?,
-            LazyJavaCommand::Sync { args } => Self::sync(args, &mut context)?,
-            LazyJavaCommand::Create { args: _ } => panic!("Should be handled earlier"),
-        };
-        Ok(())
+    fn clean_internal(all_args: &LazyJavaArgs) -> Result<(), LazyJavaError> {
+        let ctx = Context::new(all_args)?;
+        Self::clean(&ctx)
+    }
+
+    fn find_internal(all_args: &LazyJavaArgs, args: &FindArgs) -> Result<(), LazyJavaError> {
+        let ctx = Context::new(all_args)?;
+        ctx.assert_src_exists()?;
+        Self::find(args, &ctx)
+    }
+
+    fn run_internal(all_args: &LazyJavaArgs, args: &RunArgs) -> Result<(), LazyJavaError> {
+        let ctx = Context::new(all_args)?;
+        ctx.assert_build_lib_src()?;
+        Self::run(args, &ctx)
+    }
+
+    fn add_internal(all_args: &LazyJavaArgs, args: &AddArgs) -> Result<(), LazyJavaError> {
+        let mut ctx = Context::new(all_args)?;
+        ctx.assert_build_lib_src()?;
+        Self::add(args, &mut ctx)
+    }
+
+    fn remove_internal(all_args: &LazyJavaArgs, args: &RemoveArgs) -> Result<(), LazyJavaError> {
+        let mut ctx = Context::new(all_args)?;
+        ctx.assert_build_lib_src()?;
+        Self::remove(args, &mut ctx)
+    }
+
+    fn sync_internal(all_args: &LazyJavaArgs, args: &SyncArgs) -> Result<(), LazyJavaError> {
+        let mut ctx = Context::new(all_args)?;
+        ctx.assert_build_lib_src()?;
+        Self::sync(args, &mut ctx)
     }
 }

--- a/src/lazy_java.rs
+++ b/src/lazy_java.rs
@@ -8,12 +8,11 @@ pub struct LazyJava;
 impl LazyJava {
     pub fn execute(args: LazyJavaArgs) -> Result<(), LazyJavaError> {
         // commands that do not require contexts go here
-        match &args.command {
-            LazyJavaCommand::Create { args } => Self::create(args)?,
-            _ => (),
+        if let LazyJavaCommand::Create { args } = &args.command {
+            Self::create(args)?;
         }
 
-        let context = Context::new(&args)?;
+        let mut context = Context::new(&args)?;
 
         // commands that require contexts go here
         match &args.command {
@@ -21,10 +20,10 @@ impl LazyJava {
             LazyJavaCommand::Build { args } => Self::build(args, &context)?,
             LazyJavaCommand::Clean {} => Self::clean(&context)?,
             LazyJavaCommand::Find { args } => Self::find(args, &context)?,
-            LazyJavaCommand::Add { args } => Self::add(args, &context)?,
-            LazyJavaCommand::Remove { args } => Self::remove(args, &context)?,
-            LazyJavaCommand::Sync { args } => Self::sync(args, &context)?,
-            _ => (),
+            LazyJavaCommand::Add { args } => Self::add(args, &mut context)?,
+            LazyJavaCommand::Remove { args } => Self::remove(args, &mut context)?,
+            LazyJavaCommand::Sync { args } => Self::sync(args, &mut context)?,
+            LazyJavaCommand::Create { args: _ } => panic!("Should be handled earlier"),
         };
         Ok(())
     }

--- a/src/lazy_java.rs
+++ b/src/lazy_java.rs
@@ -1,85 +1,31 @@
-use std::{
-    env,
-    path::{self, PathBuf},
-};
-
 use crate::{
+    Context,
     args::{LazyJavaArgs, LazyJavaCommand},
     lazy_java_error::LazyJavaError,
-    utils::find_root::find_root,
 };
-
-#[derive(Debug, Clone)]
-pub struct LazyJava {
-    pub src: PathBuf,
-    pub build: PathBuf,
-    pub lib: PathBuf,
-    pub root: PathBuf,
-    pub args: LazyJavaArgs,
-}
+pub struct LazyJava;
 
 impl LazyJava {
-    pub fn new(args: LazyJavaArgs) -> Result<LazyJava, LazyJavaError> {
-        let current = env::current_dir().map_err(LazyJavaError::NoCurrentDir)?;
-        log::debug!("Current directory: {:?}", current);
+    pub fn execute(args: LazyJavaArgs) -> Result<(), LazyJavaError> {
+        // commands that do not require contexts go here
+        match &args.command {
+            LazyJavaCommand::Create { args } => Self::create(args)?,
+            _ => (),
+        }
 
-        let root = find_root(&current).map_err(|_e| {
-            log::error!("Could not locate project root");
-            LazyJavaError::NoRoot
-        })?;
-        let root = root.unwrap_or(env::current_dir().map_err(|_e| LazyJavaError::NoRoot)?);
-        log::info!("Project root: {:?}", root);
+        let context = Context::new(&args)?;
 
-        let mut lib = root.clone();
-        lib.push(args.global_args.lib.clone());
-        let mut src = root.clone();
-        src.push(args.global_args.source.clone());
-        let mut build = root.clone();
-        build.push(args.global_args.build.clone());
-
-        log::debug!("Source directory: {:?}", src);
-        log::debug!("Build directory: {:?}", build);
-        log::debug!("Library directory: {:?}", lib);
-
-        let lazy_java = LazyJava {
-            src,
-            build,
-            lib,
-            root,
-            args,
+        // commands that require contexts go here
+        match &args.command {
+            LazyJavaCommand::Run { args } => Self::run(args, &context)?,
+            LazyJavaCommand::Build { args } => Self::build(args, &context)?,
+            LazyJavaCommand::Clean {} => Self::clean(&context)?,
+            LazyJavaCommand::Find { args } => Self::find(args, &context)?,
+            LazyJavaCommand::Add { args } => Self::add(args, &context)?,
+            LazyJavaCommand::Remove { args } => Self::remove(args, &context)?,
+            LazyJavaCommand::Sync { args } => Self::sync(args, &context)?,
+            _ => (),
         };
-
-        Ok(lazy_java)
-    }
-
-    pub fn execute(&self) -> Result<(), LazyJavaError> {
-        match &self.args.command {
-            LazyJavaCommand::Run { args } => self.run(args)?,
-            LazyJavaCommand::Build { args } => self.build(args)?,
-            LazyJavaCommand::Clean {} => self.clean()?,
-            LazyJavaCommand::Find { args } => self.find(args)?,
-            LazyJavaCommand::Create { args } => self.create(args)?,
-            LazyJavaCommand::Add { args } => self.add(args)?,
-            LazyJavaCommand::Remove { args } => self.remove(args)?,
-            LazyJavaCommand::Sync { args } => self.sync(args)?,
-        };
-        Ok(())
-    }
-
-    pub fn assert_build_lib_src(&self) -> Result<(), LazyJavaError> {
-        if !self.src.exists() {
-            let path = path::absolute(self.src.clone()).unwrap();
-            return Err(LazyJavaError::NoSource(path.to_string_lossy().into()));
-        }
-
-        if !self.build.exists() {
-            let path = path::absolute(self.build.clone()).unwrap();
-            return Err(LazyJavaError::NoBuild(path.to_string_lossy().into()));
-        }
-        if !self.lib.exists() {
-            let path = path::absolute(self.lib.clone()).unwrap();
-            return Err(LazyJavaError::NoLib(path.to_string_lossy().into()));
-        }
         Ok(())
     }
 }

--- a/src/lazy_java_error.rs
+++ b/src/lazy_java_error.rs
@@ -36,7 +36,7 @@ pub enum LazyJavaError {
     #[error(
         "Could not locate root, no root markers were found, try adding in a root marker or manually specify a root"
     )]
-    NoRoot,
+    NoRoot(io::Error),
 
     #[error("Unable to find main classes, {0}")]
     CouldntFindMains(io::Error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod args;
 pub mod build;
 pub mod clean;
 pub mod config;
+mod context;
 pub mod create;
 pub mod dependancy_graph;
 pub mod find;
@@ -18,6 +19,7 @@ pub mod packages;
 pub mod run;
 pub mod utils;
 
+pub use context::Context;
 pub use lazy_java::LazyJava;
 
 pub const BUILD_FOLDER: &str = "bin";

--- a/src/lsp/classpath_impl.rs
+++ b/src/lsp/classpath_impl.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 use std::io::Cursor;
 
 use crate::{
-    lazy_java::LazyJava,
+    Context,
     lsp::{
         classpath::{Classpath, ClasspathEntry},
         classpath_error::ClasspathError,
@@ -42,14 +42,13 @@ impl Classpath {
 
         Ok(classpath)
     }
-    pub fn generate(lj: &LazyJava) -> Result<(), ClasspathError> {
+    pub fn generate(ctx: &Context) -> Result<(), ClasspathError> {
         log::info!("Generating classpath file");
-        let classpath = Self::create(lj)?;
+        let classpath = Self::create(ctx)?;
 
         let serialized = Self::to_pretty_xml(&classpath)?;
 
-        let mut path = lj.root.clone();
-        path.push(".classpath");
+        let path = ctx.root.join(".classpath");
 
         log::debug!("Writing classpath to {:?}", path);
         fs::write(&path, serialized).map_err(|e| {
@@ -64,12 +63,10 @@ impl Classpath {
         Ok(())
     }
 
-    fn create(lj: &LazyJava) -> Result<Classpath, ClasspathError> {
+    fn create(ctx: &Context) -> Result<Classpath, ClasspathError> {
         log::debug!("Creating classpath from project structure");
-        let src = &lj.args.global_args.source;
-        let build = &lj.args.global_args.build;
 
-        let dir = Self::lib_files(&lj.lib)?;
+        let dir = Self::lib_files(&ctx.lib)?;
         log::debug!("Found {} library files", dir.len());
 
         let mut entries: Vec<ClasspathEntry> = dir
@@ -85,9 +82,9 @@ impl Classpath {
 
         entries.push(ClasspathEntry {
             kind: "src".into(),
-            path: src.into(),
+            path: ctx.relative_src.clone(),
             including: None,
-            output: Some(build.into()),
+            output: Some(ctx.relative_bin.clone()),
             attributes: None,
         });
 
@@ -137,9 +134,9 @@ impl Classpath {
         log::debug!("Found {} JAR files in library directory", java_files.len());
         Ok(java_files)
     }
-    fn validate(lj: &LazyJava) -> Result<bool, ClasspathError> {
+    fn validate(ctx: &Context) -> Result<bool, ClasspathError> {
         log::debug!("Validating classpath file");
-        let root = &lj.root;
+        let root = &ctx.root;
 
         let classpath = match Self::parse(&root.join(".classpath")) {
             Ok(cp) => cp,
@@ -161,16 +158,16 @@ impl Classpath {
         if let Some(classpath_src) = classpath_src {
             let c_src = path::absolute(Path::new(&classpath_src.path))
                 .map_err(|_| ClasspathError::PathError(classpath_src.path.to_string()))?;
-            let src = path::absolute(&lj.src)
-                .map_err(|_| ClasspathError::PathError(lj.src.to_string_lossy().to_string()))?;
+            let src = path::absolute(&ctx.src)
+                .map_err(|_| ClasspathError::PathError(ctx.src.to_string_lossy().to_string()))?;
 
             let c_output =
                 path::absolute(Path::new(&classpath_src.output.clone().unwrap_or_default()))
                     .map_err(|_| {
                         ClasspathError::PathError(classpath_src.output.clone().unwrap_or_default())
                     })?;
-            let build = path::absolute(Path::new(&lj.build))
-                .map_err(|_| ClasspathError::PathError(lj.build.to_string_lossy().to_string()))?;
+            let build = path::absolute(Path::new(&ctx.bin))
+                .map_err(|_| ClasspathError::PathError(ctx.bin.to_string_lossy().to_string()))?;
 
             if (c_src != src) || (c_output != build) {
                 log::debug!("Classpath source entry is out of date");
@@ -191,7 +188,7 @@ impl Classpath {
             return Ok(false);
         }
 
-        let libs: Vec<String> = Self::lib_files(&lj.lib)?
+        let libs: Vec<String> = Self::lib_files(&ctx.lib)?
             .iter()
             .map(|path| path.to_string_lossy().to_string())
             .collect();
@@ -206,11 +203,11 @@ impl Classpath {
 
         Ok(equal)
     }
-    pub fn generate_if_stale(lj: &LazyJava) -> Result<(), ClasspathError> {
+    pub fn generate_if_stale(ctx: &Context) -> Result<(), ClasspathError> {
         log::debug!("Checking if classpath needs regeneration");
-        if !(Self::validate(lj)?) {
+        if !(Self::validate(ctx)?) {
             log::info!("Classpath is stale, regenerating");
-            Self::generate(lj)?
+            Self::generate(ctx)?
         } else {
             log::debug!("Classpath is up to date");
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,8 +18,7 @@ fn main() -> Result<()> {
         .format_timestamp(None)
         .init();
 
-    let lazy = LazyJava::new(args)?;
-    lazy.execute()?;
+    LazyJava::execute(args)?;
 
     Ok(())
 }

--- a/src/packages/add.rs
+++ b/src/packages/add.rs
@@ -1,12 +1,12 @@
 use colored::Colorize;
 
 use crate::{
-    args::AddArgs, config::Config, lazy_java::LazyJava, lazy_java_error::LazyJavaError,
+    Context, args::AddArgs, config::Config, lazy_java::LazyJava, lazy_java_error::LazyJavaError,
     lsp::classpath::Classpath,
 };
 
 impl LazyJava {
-    pub fn add(&self, add_args: &AddArgs) -> Result<(), LazyJavaError> {
+    pub fn add(add_args: &AddArgs, ctx: &Context) -> Result<(), LazyJavaError> {
         if add_args.dry_run {
             println!(
                 "{} ({} will be made)",
@@ -14,15 +14,15 @@ impl LazyJava {
                 "No persistent changes".red().bold(),
             )
         }
-        self.assert_build_lib_src()?;
 
-        let mut config = Config::fetch(&self.root)?;
+        let mut config = Config::fetch(&ctx.root)?;
 
-        config.add_package(&add_args, &self.root, &self.lib)?;
+        config.add_package(&add_args, &ctx.root, &ctx.lib)?;
 
-        config.write(&self.root)?;
+        config.write(&ctx.root)?;
+
         if !add_args.dry_run {
-            Classpath::generate(self)?;
+            Classpath::generate(ctx)?;
         }
 
         Ok(())

--- a/src/packages/add.rs
+++ b/src/packages/add.rs
@@ -1,12 +1,12 @@
 use colored::Colorize;
 
 use crate::{
-    Context, args::AddArgs, config::Config, lazy_java::LazyJava, lazy_java_error::LazyJavaError,
+    Context, args::AddArgs, lazy_java::LazyJava, lazy_java_error::LazyJavaError,
     lsp::classpath::Classpath,
 };
 
 impl LazyJava {
-    pub fn add(add_args: &AddArgs, ctx: &Context) -> Result<(), LazyJavaError> {
+    pub fn add(add_args: &AddArgs, ctx: &mut Context) -> Result<(), LazyJavaError> {
         if add_args.dry_run {
             println!(
                 "{} ({} will be made)",
@@ -15,7 +15,7 @@ impl LazyJava {
             )
         }
 
-        let mut config = Config::fetch(&ctx.root)?;
+        let config = &mut ctx.config;
 
         config.add_package(&add_args, &ctx.root, &ctx.lib)?;
 

--- a/src/packages/remove.rs
+++ b/src/packages/remove.rs
@@ -1,12 +1,11 @@
 use colored::Colorize;
 
 use crate::{
-    Context, LazyJava, args::RemoveArgs, config::Config, lazy_java_error::LazyJavaError,
-    lsp::classpath::Classpath,
+    Context, LazyJava, args::RemoveArgs, lazy_java_error::LazyJavaError, lsp::classpath::Classpath,
 };
 
 impl LazyJava {
-    pub fn remove(remove_args: &RemoveArgs, ctx: &Context) -> Result<(), LazyJavaError> {
+    pub fn remove(remove_args: &RemoveArgs, ctx: &mut Context) -> Result<(), LazyJavaError> {
         if remove_args.dry_run {
             println!(
                 "{} ({} will be made)",
@@ -15,11 +14,10 @@ impl LazyJava {
             )
         }
 
-        let mut config = Config::fetch(&ctx.root)?;
+        ctx.config
+            .remove_package(remove_args, &ctx.root, &ctx.lib)?;
 
-        config.remove_package(remove_args, &ctx.root, &ctx.lib)?;
-
-        config.write(&ctx.root)?;
+        ctx.config.write(&ctx.root)?;
         if !remove_args.dry_run {
             Classpath::generate(ctx)?;
         }

--- a/src/packages/remove.rs
+++ b/src/packages/remove.rs
@@ -1,12 +1,12 @@
 use colored::Colorize;
 
 use crate::{
-    LazyJava, args::RemoveArgs, config::Config, lazy_java_error::LazyJavaError,
+    Context, LazyJava, args::RemoveArgs, config::Config, lazy_java_error::LazyJavaError,
     lsp::classpath::Classpath,
 };
 
 impl LazyJava {
-    pub fn remove(&self, remove_args: &RemoveArgs) -> Result<(), LazyJavaError> {
+    pub fn remove(remove_args: &RemoveArgs, ctx: &Context) -> Result<(), LazyJavaError> {
         if remove_args.dry_run {
             println!(
                 "{} ({} will be made)",
@@ -14,15 +14,14 @@ impl LazyJava {
                 "No persistent changes".red().bold(),
             )
         }
-        self.assert_build_lib_src()?;
 
-        let mut config = Config::fetch(&self.root)?;
+        let mut config = Config::fetch(&ctx.root)?;
 
-        config.remove_package(remove_args, &self.root, &self.lib)?;
+        config.remove_package(remove_args, &ctx.root, &ctx.lib)?;
 
-        config.write(&self.root)?;
+        config.write(&ctx.root)?;
         if !remove_args.dry_run {
-            Classpath::generate(self)?;
+            Classpath::generate(ctx)?;
         }
 
         Ok(())

--- a/src/packages/sync_packages.rs
+++ b/src/packages/sync_packages.rs
@@ -1,12 +1,12 @@
 use colored::Colorize;
 
 use crate::{
-    Context, args::SyncArgs, config::Config, lazy_java::LazyJava, lazy_java_error::LazyJavaError,
+    Context, args::SyncArgs, lazy_java::LazyJava, lazy_java_error::LazyJavaError,
     lock_file::LockFile, lsp::classpath::Classpath,
 };
 
 impl LazyJava {
-    pub fn sync(sync_args: &SyncArgs, ctx: &Context) -> Result<(), LazyJavaError> {
+    pub fn sync(sync_args: &SyncArgs, ctx: &mut Context) -> Result<(), LazyJavaError> {
         if sync_args.dry_run {
             println!(
                 "{} ({} will be made)",
@@ -15,7 +15,7 @@ impl LazyJava {
             )
         }
 
-        let config = Config::fetch(&ctx.root)?;
+        let config = &mut ctx.config;
         let mut lockfile = LockFile::fetch(&ctx.root)?;
 
         config.sync_lock_file(&mut lockfile, &ctx.root, &ctx.lib, sync_args.dry_run)?;

--- a/src/packages/sync_packages.rs
+++ b/src/packages/sync_packages.rs
@@ -1,12 +1,12 @@
 use colored::Colorize;
 
 use crate::{
-    args::SyncArgs, config::Config, lazy_java::LazyJava, lazy_java_error::LazyJavaError,
+    Context, args::SyncArgs, config::Config, lazy_java::LazyJava, lazy_java_error::LazyJavaError,
     lock_file::LockFile, lsp::classpath::Classpath,
 };
 
 impl LazyJava {
-    pub fn sync(&self, sync_args: &SyncArgs) -> Result<(), LazyJavaError> {
+    pub fn sync(sync_args: &SyncArgs, ctx: &Context) -> Result<(), LazyJavaError> {
         if sync_args.dry_run {
             println!(
                 "{} ({} will be made)",
@@ -15,17 +15,15 @@ impl LazyJava {
             )
         }
 
-        self.assert_build_lib_src()?;
+        let config = Config::fetch(&ctx.root)?;
+        let mut lockfile = LockFile::fetch(&ctx.root)?;
 
-        let config = Config::fetch(&self.root)?;
-        let mut lockfile = LockFile::fetch(&self.root)?;
+        config.sync_lock_file(&mut lockfile, &ctx.root, &ctx.lib, sync_args.dry_run)?;
 
-        config.sync_lock_file(&mut lockfile, &self.root, &self.lib, sync_args.dry_run)?;
-
-        config.write(&self.root)?;
+        config.write(&ctx.root)?;
 
         if !sync_args.dry_run {
-            Classpath::generate(self)?;
+            Classpath::generate(ctx)?;
         }
 
         Ok(())

--- a/src/run/interactive_run.rs
+++ b/src/run/interactive_run.rs
@@ -1,43 +1,34 @@
 use inquire::Select;
 
-use crate::{
-    lazy_java::LazyJava, lazy_java_error::LazyJavaError, utils::find_main::find_main_classes,
-};
+use crate::{Context, lazy_java_error::LazyJavaError, utils::find_main::find_main_classes};
 
-impl LazyJava {
-    pub fn interactive_find_main(&self) -> Result<String, LazyJavaError> {
-        log::debug!("Finding main classes interactively");
-        let options =
-            find_main_classes(&self.src).map_err(LazyJavaError::CouldntFindMains)?;
-        log::debug!("Found {} main classes", options.len());
+pub fn interactive_find_main(ctx: &Context) -> Result<String, LazyJavaError> {
+    log::debug!("Finding main classes interactively");
+    let options = find_main_classes(&ctx.src).map_err(LazyJavaError::CouldntFindMains)?;
+    log::debug!("Found {} main classes", options.len());
 
-        if options.is_empty() {
-            log::error!("No main classes found");
-            return Err(LazyJavaError::NoMainClasses);
-        }
-
-        if options.len() == 1 {
-            log::debug!(
-                "Only one main class found: {}",
-                options[0].full_package_name
-            );
-            return Ok(options[0].full_package_name.clone());
-        }
-
-        let configured_options: Vec<String> = options
-            .into_iter()
-            .map(|op| {
-                op.full_package_name
-            })
-            .collect();
-
-        let res = Select::new("Select a Main Class to Run: ", configured_options)
-            .without_help_message()
-            .without_filtering()
-            .prompt()
-            .map_err(|_e| LazyJavaError::PromptError)?;
-        log::debug!("User selected main class: {}", res);
-
-        Ok(res)
+    if options.is_empty() {
+        log::error!("No main classes found");
+        return Err(LazyJavaError::NoMainClasses);
     }
+
+    if options.len() == 1 {
+        log::debug!(
+            "Only one main class found: {}",
+            options[0].full_package_name
+        );
+        return Ok(options[0].full_package_name.clone());
+    }
+
+    let configured_options: Vec<String> =
+        options.into_iter().map(|op| op.full_package_name).collect();
+
+    let res = Select::new("Select a Main Class to Run: ", configured_options)
+        .without_help_message()
+        .without_filtering()
+        .prompt()
+        .map_err(|_e| LazyJavaError::PromptError)?;
+    log::debug!("User selected main class: {}", res);
+
+    Ok(res)
 }

--- a/src/run/run_java.rs
+++ b/src/run/run_java.rs
@@ -1,25 +1,24 @@
 use crate::{
-    args::RunArgs, lazy_java::LazyJava, lazy_java_error::LazyJavaError,
-    utils::processes::execute_java,
+    Context, args::RunArgs, lazy_java::LazyJava, lazy_java_error::LazyJavaError,
+    run::interactive_run::interactive_find_main, utils::processes::execute_java,
 };
 
 impl LazyJava {
-    pub fn run(&self, args: &RunArgs) -> Result<(), LazyJavaError> {
-        self.assert_build_lib_src()?;
+    pub fn run(args: &RunArgs, ctx: &Context) -> Result<(), LazyJavaError> {
         log::info!("Starting run operation");
 
         if !args.no_build {
             log::debug!("Building before run");
-            self.build_java(&args.build_args)?;
+            Self::build_java(&args.build_args, ctx)?;
         }
 
         let class = match &args.class {
             Some(class) => class,
-            None => &self.interactive_find_main()?,
+            None => &interactive_find_main(ctx)?,
         };
         log::debug!("Running class: {}", class);
 
-        execute_java(class, &self.build, &self.lib, &args.args)
+        execute_java(class, &ctx.bin, &ctx.lib, &args.args)
             .map_err(|_e| LazyJavaError::InvalidMainClass(class.to_string()))?;
 
         log::info!("Java execution completed successfully");

--- a/test_filesystem/project/.classpath
+++ b/test_filesystem/project/.classpath
@@ -40,6 +40,9 @@
     <classpathentry kind="lib" path="/Users/lucasvanderwielen/Projects/Rust/lazy-java/test_filesystem/project/lib/spring-webmvc-7.0.8.jar" including="" output="">
         <attributes/>
     </classpathentry>
+    <classpathentry kind="lib" path="/Users/lucasvanderwielen/Projects/Rust/lazy-java/test_filesystem/project/lib/guava-33.6.0-jre.jar" including="" output="">
+        <attributes/>
+    </classpathentry>
     <classpathentry kind="lib" path="/Users/lucasvanderwielen/Projects/Rust/lazy-java/test_filesystem/project/lib/slf4j-api-2.0.18.jar" including="" output="">
         <attributes/>
     </classpathentry>
@@ -67,7 +70,13 @@
     <classpathentry kind="lib" path="/Users/lucasvanderwielen/Projects/Rust/lazy-java/test_filesystem/project/lib/spring-boot-autoconfigure-4.1.0.jar" including="" output="">
         <attributes/>
     </classpathentry>
+    <classpathentry kind="lib" path="/Users/lucasvanderwielen/Projects/Rust/lazy-java/test_filesystem/project/lib/failureaccess-1.0.3.jar" including="" output="">
+        <attributes/>
+    </classpathentry>
     <classpathentry kind="lib" path="/Users/lucasvanderwielen/Projects/Rust/lazy-java/test_filesystem/project/lib/jackson-annotations-2.21.jar" including="" output="">
+        <attributes/>
+    </classpathentry>
+    <classpathentry kind="lib" path="/Users/lucasvanderwielen/Projects/Rust/lazy-java/test_filesystem/project/lib/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar" including="" output="">
         <attributes/>
     </classpathentry>
     <classpathentry kind="lib" path="/Users/lucasvanderwielen/Projects/Rust/lazy-java/test_filesystem/project/lib/spring-expression-7.0.8.jar" including="" output="">
@@ -91,6 +100,9 @@
     <classpathentry kind="lib" path="/Users/lucasvanderwielen/Projects/Rust/lazy-java/test_filesystem/project/lib/spring-boot-starter-tomcat-4.1.0.jar" including="" output="">
         <attributes/>
     </classpathentry>
+    <classpathentry kind="lib" path="/Users/lucasvanderwielen/Projects/Rust/lazy-java/test_filesystem/project/lib/j2objc-annotations-3.1.jar" including="" output="">
+        <attributes/>
+    </classpathentry>
     <classpathentry kind="lib" path="/Users/lucasvanderwielen/Projects/Rust/lazy-java/test_filesystem/project/lib/spring-core-7.0.8.jar" including="" output="">
         <attributes/>
     </classpathentry>
@@ -104,6 +116,9 @@
         <attributes/>
     </classpathentry>
     <classpathentry kind="lib" path="/Users/lucasvanderwielen/Projects/Rust/lazy-java/test_filesystem/project/lib/spring-boot-tomcat-4.1.0.jar" including="" output="">
+        <attributes/>
+    </classpathentry>
+    <classpathentry kind="lib" path="/Users/lucasvanderwielen/Projects/Rust/lazy-java/test_filesystem/project/lib/error_prone_annotations-2.47.0.jar" including="" output="">
         <attributes/>
     </classpathentry>
     <classpathentry kind="lib" path="/Users/lucasvanderwielen/Projects/Rust/lazy-java/test_filesystem/project/lib/jul-to-slf4j-2.0.18.jar" including="" output="">

--- a/test_filesystem/project/lazy-java.lock
+++ b/test_filesystem/project/lazy-java.lock
@@ -1,33 +1,360 @@
 [[package]]
 group = "org.springframework"
-artifact = "spring-context"
+artifact = "spring-aop"
 version = "7.0.8"
-file_name = "spring-context-7.0.8.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/spring-context/7.0.8/spring-context-7.0.8.jar"
+file_name = "spring-aop-7.0.8.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/spring-aop/7.0.8/spring-aop-7.0.8.jar"
+dependancies = []
+packaging = "jar"
+root = false
+
+[[package]]
+group = "org.apache.tomcat"
+artifact = "tomcat-annotations-api"
+version = "11.0.22"
+file_name = "tomcat-annotations-api-11.0.22.jar"
+url = "https://repo1.maven.org/maven2/org/apache/tomcat/tomcat-annotations-api/11.0.22/tomcat-annotations-api-11.0.22.jar"
+dependancies = []
+packaging = "jar"
+root = false
+
+[[package]]
+group = "org.springframework.boot"
+artifact = "spring-boot-starter-tomcat-runtime"
+version = "4.1.0"
+file_name = "spring-boot-starter-tomcat-runtime-4.1.0.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter-tomcat-runtime/4.1.0/spring-boot-starter-tomcat-runtime-4.1.0.jar"
+packaging = "jar"
+root = false
+
+[[package.dependancies]]
+group = "org.springframework.boot"
+artifact = "spring-boot-web-server"
+version = "4.1.0"
+
+[[package.dependancies]]
+group = "org.apache.tomcat.embed"
+artifact = "tomcat-embed-el"
+version = "11.0.22"
+
+[[package.dependancies]]
+group = "org.apache.tomcat.embed"
+artifact = "tomcat-embed-websocket"
+version = "11.0.22"
+
+[[package.dependancies]]
+group = "jakarta.annotation"
+artifact = "jakarta.annotation-api"
+version = "3.0.0"
+
+[[package.dependancies]]
+group = "org.apache.tomcat.embed"
+artifact = "tomcat-embed-core"
+version = "11.0.22"
+
+[[package]]
+group = "org.slf4j"
+artifact = "jul-to-slf4j"
+version = "2.0.18"
+file_name = "jul-to-slf4j-2.0.18.jar"
+url = "https://repo1.maven.org/maven2/org/slf4j/jul-to-slf4j/2.0.18/jul-to-slf4j-2.0.18.jar"
+packaging = "jar"
+root = false
+
+[[package.dependancies]]
+group = "org.slf4j"
+artifact = "slf4j-api"
+version = "2.0.18"
+
+[[package]]
+group = "org.springframework.boot"
+artifact = "spring-boot-webmvc"
+version = "4.1.0"
+file_name = "spring-boot-webmvc-4.1.0.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-webmvc/4.1.0/spring-boot-webmvc-4.1.0.jar"
 packaging = "jar"
 root = false
 
 [[package.dependancies]]
 group = "org.springframework"
-artifact = "spring-aop"
+artifact = "spring-web"
 version = "7.0.8"
 
 [[package.dependancies]]
-group = "org.springframework"
-artifact = "spring-beans"
-version = "7.0.8"
+group = "org.springframework.boot"
+artifact = "spring-boot-servlet"
+version = "4.1.0"
+
+[[package.dependancies]]
+group = "org.springframework.boot"
+artifact = "spring-boot-http-converter"
+version = "4.1.0"
 
 [[package.dependancies]]
 group = "org.springframework"
-artifact = "spring-expression"
+artifact = "spring-webmvc"
 version = "7.0.8"
 
 [[package]]
+group = "org.springframework.boot"
+artifact = "spring-boot-jackson"
+version = "4.1.0"
+file_name = "spring-boot-jackson-4.1.0.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-jackson/4.1.0/spring-boot-jackson-4.1.0.jar"
+packaging = "jar"
+root = false
+
+[[package.dependancies]]
+group = "tools.jackson.core"
+artifact = "jackson-databind"
+version = "3.1.4"
+
+[[package]]
+group = "tools.jackson.core"
+artifact = "jackson-core"
+version = "3.1.4"
+file_name = "jackson-core-3.1.4.jar"
+url = "https://repo1.maven.org/maven2/tools/jackson/core/jackson-core/3.1.4/jackson-core-3.1.4.jar"
+dependancies = []
+packaging = "jar"
+root = false
+
+[[package]]
+group = "jakarta.annotation"
+artifact = "jakarta.annotation-api"
+version = "3.0.0"
+file_name = "jakarta.annotation-api-3.0.0.jar"
+url = "https://repo1.maven.org/maven2/jakarta/annotation/jakarta.annotation-api/3.0.0/jakarta.annotation-api-3.0.0.jar"
+dependancies = []
+packaging = "jar"
+root = false
+
+[[package]]
+group = "org.slf4j"
+artifact = "slf4j-api"
+version = "2.0.18"
+file_name = "slf4j-api-2.0.18.jar"
+url = "https://repo1.maven.org/maven2/org/slf4j/slf4j-api/2.0.18/slf4j-api-2.0.18.jar"
+dependancies = []
+packaging = "jar"
+root = false
+
+[[package]]
+group = "com.fasterxml.jackson.core"
+artifact = "jackson-annotations"
+version = "2.21"
+file_name = "jackson-annotations-2.21.jar"
+url = "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21.jar"
+dependancies = []
+packaging = "jar"
+root = false
+
+[[package]]
+group = "com.google.guava"
+artifact = "listenablefuture"
+version = "9999.0-empty-to-avoid-conflict-with-guava"
+file_name = "listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"
+url = "https://repo1.maven.org/maven2/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"
+dependancies = []
+packaging = "jar"
+root = false
+
+[[package]]
+group = "io.micrometer"
+artifact = "micrometer-observation"
+version = "1.16.6"
+file_name = "micrometer-observation-1.16.6.jar"
+url = "https://repo1.maven.org/maven2/io/micrometer/micrometer-observation/1.16.6/micrometer-observation-1.16.6.jar"
+packaging = "jar"
+root = false
+
+[[package.dependancies]]
+group = "io.micrometer"
+artifact = "micrometer-commons"
+version = "1.16.6"
+
+[[package.dependancies]]
+group = "org.jspecify"
+artifact = "jspecify"
+version = "1.0.0"
+
+[[package]]
+group = "org.springframework.boot"
+artifact = "spring-boot-web-server"
+version = "4.1.0"
+file_name = "spring-boot-web-server-4.1.0.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-web-server/4.1.0/spring-boot-web-server-4.1.0.jar"
+dependancies = []
+packaging = "jar"
+root = false
+
+[[package]]
+group = "org.springframework.boot"
+artifact = "spring-boot-tomcat"
+version = "4.1.0"
+file_name = "spring-boot-tomcat-4.1.0.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-tomcat/4.1.0/spring-boot-tomcat-4.1.0.jar"
+packaging = "jar"
+root = false
+
+[[package.dependancies]]
+group = "org.springframework.boot"
+artifact = "spring-boot-web-server"
+version = "4.1.0"
+
+[[package.dependancies]]
+group = "jakarta.annotation"
+artifact = "jakarta.annotation-api"
+version = "3.0.0"
+
+[[package.dependancies]]
+group = "org.apache.tomcat.embed"
+artifact = "tomcat-embed-core"
+version = "11.0.22"
+
+[[package]]
+group = "com.google.errorprone"
+artifact = "error_prone_annotations"
+version = "2.47.0"
+file_name = "error_prone_annotations-2.47.0.jar"
+url = "https://repo1.maven.org/maven2/com/google/errorprone/error_prone_annotations/2.47.0/error_prone_annotations-2.47.0.jar"
+dependancies = []
+packaging = "jar"
+root = false
+
+[[package]]
+group = "org.springframework.boot"
+artifact = "spring-boot-http-converter"
+version = "4.1.0"
+file_name = "spring-boot-http-converter-4.1.0.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-http-converter/4.1.0/spring-boot-http-converter-4.1.0.jar"
+packaging = "jar"
+root = false
+
+[[package.dependancies]]
 group = "org.springframework"
-artifact = "spring-aop"
+artifact = "spring-web"
 version = "7.0.8"
-file_name = "spring-aop-7.0.8.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/spring-aop/7.0.8/spring-aop-7.0.8.jar"
+
+[[package.dependancies]]
+group = "org.springframework.boot"
+artifact = "spring-boot"
+version = "4.1.0"
+
+[[package]]
+group = "org.yaml"
+artifact = "snakeyaml"
+version = "2.6"
+file_name = "snakeyaml-2.6.jar"
+url = "https://repo1.maven.org/maven2/org/yaml/snakeyaml/2.6/snakeyaml-2.6.jar"
+dependancies = []
+packaging = "bundle"
+root = false
+
+[[package]]
+group = "ch.qos.logback"
+artifact = "logback-core"
+version = "1.5.34"
+file_name = "logback-core-1.5.34.jar"
+url = "https://repo1.maven.org/maven2/ch/qos/logback/logback-core/1.5.34/logback-core-1.5.34.jar"
+dependancies = []
+packaging = "jar"
+root = false
+
+[[package]]
+group = "org.apache.tomcat.embed"
+artifact = "tomcat-embed-websocket"
+version = "11.0.22"
+file_name = "tomcat-embed-websocket-11.0.22.jar"
+url = "https://repo1.maven.org/maven2/org/apache/tomcat/embed/tomcat-embed-websocket/11.0.22/tomcat-embed-websocket-11.0.22.jar"
+dependancies = []
+packaging = "jar"
+root = false
+
+[[package]]
+group = "org.apache.logging.log4j"
+artifact = "log4j-api"
+version = "2.25.4"
+file_name = "log4j-api-2.25.4.jar"
+url = "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.25.4/log4j-api-2.25.4.jar"
+dependancies = []
+packaging = "jar"
+root = false
+
+[[package]]
+group = "org.springframework.boot"
+artifact = "spring-boot-autoconfigure"
+version = "4.1.0"
+file_name = "spring-boot-autoconfigure-4.1.0.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-autoconfigure/4.1.0/spring-boot-autoconfigure-4.1.0.jar"
+dependancies = []
+packaging = "jar"
+root = false
+
+[[package]]
+group = "org.apache.tomcat.embed"
+artifact = "tomcat-embed-el"
+version = "11.0.22"
+file_name = "tomcat-embed-el-11.0.22.jar"
+url = "https://repo1.maven.org/maven2/org/apache/tomcat/embed/tomcat-embed-el/11.0.22/tomcat-embed-el-11.0.22.jar"
+dependancies = []
+packaging = "jar"
+root = false
+
+[[package]]
+group = "org.apache.tomcat.embed"
+artifact = "tomcat-embed-core"
+version = "11.0.22"
+file_name = "tomcat-embed-core-11.0.22.jar"
+url = "https://repo1.maven.org/maven2/org/apache/tomcat/embed/tomcat-embed-core/11.0.22/tomcat-embed-core-11.0.22.jar"
+packaging = "jar"
+root = false
+
+[[package.dependancies]]
+group = "org.apache.tomcat"
+artifact = "tomcat-annotations-api"
+version = "11.0.22"
+
+[[package]]
+group = "org.springframework.boot"
+artifact = "spring-boot-starter-logging"
+version = "4.1.0"
+file_name = "spring-boot-starter-logging-4.1.0.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter-logging/4.1.0/spring-boot-starter-logging-4.1.0.jar"
+packaging = "jar"
+root = false
+
+[[package.dependancies]]
+group = "org.slf4j"
+artifact = "jul-to-slf4j"
+version = "2.0.18"
+
+[[package.dependancies]]
+group = "ch.qos.logback"
+artifact = "logback-classic"
+version = "1.5.34"
+
+[[package.dependancies]]
+group = "org.apache.logging.log4j"
+artifact = "log4j-to-slf4j"
+version = "2.25.4"
+
+[[package]]
+group = "org.jspecify"
+artifact = "jspecify"
+version = "1.0.0"
+file_name = "jspecify-1.0.0.jar"
+url = "https://repo1.maven.org/maven2/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar"
+dependancies = []
+packaging = "jar"
+root = false
+
+[[package]]
+group = "commons-logging"
+artifact = "commons-logging"
+version = "1.3.5"
+file_name = "commons-logging-1.3.5.jar"
+url = "https://repo1.maven.org/maven2/commons-logging/commons-logging/1.3.5/commons-logging-1.3.5.jar"
 dependancies = []
 packaging = "jar"
 root = false
@@ -52,73 +379,254 @@ artifact = "commons-logging"
 version = "1.3.5"
 
 [[package]]
-group = "ch.qos.logback"
-artifact = "logback-core"
-version = "1.5.34"
-file_name = "logback-core-1.5.34.jar"
-url = "https://repo1.maven.org/maven2/ch/qos/logback/logback-core/1.5.34/logback-core-1.5.34.jar"
+group = "org.springframework.boot"
+artifact = "spring-boot-servlet"
+version = "4.1.0"
+file_name = "spring-boot-servlet-4.1.0.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-servlet/4.1.0/spring-boot-servlet-4.1.0.jar"
+packaging = "jar"
+root = false
+
+[[package.dependancies]]
+group = "org.springframework.boot"
+artifact = "spring-boot"
+version = "4.1.0"
+
+[[package.dependancies]]
+group = "org.springframework"
+artifact = "spring-web"
+version = "7.0.8"
+
+[[package]]
+group = "org.springframework.boot"
+artifact = "spring-boot"
+version = "4.1.0"
+file_name = "spring-boot-4.1.0.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot/4.1.0/spring-boot-4.1.0.jar"
+packaging = "jar"
+root = false
+
+[[package.dependancies]]
+group = "org.springframework"
+artifact = "spring-context"
+version = "7.0.8"
+
+[[package.dependancies]]
+group = "org.springframework"
+artifact = "spring-core"
+version = "7.0.8"
+
+[[package]]
+group = "com.google.j2objc"
+artifact = "j2objc-annotations"
+version = "3.1"
+file_name = "j2objc-annotations-3.1.jar"
+url = "https://repo1.maven.org/maven2/com/google/j2objc/j2objc-annotations/3.1/j2objc-annotations-3.1.jar"
+dependancies = []
+packaging = "jar"
+root = false
+
+[[package]]
+group = "com.google.guava"
+artifact = "failureaccess"
+version = "1.0.3"
+file_name = "failureaccess-1.0.3.jar"
+url = "https://repo1.maven.org/maven2/com/google/guava/failureaccess/1.0.3/failureaccess-1.0.3.jar"
+dependancies = []
+packaging = "jar"
+root = false
+
+[[package]]
+group = "org.springframework"
+artifact = "spring-web"
+version = "7.0.8"
+file_name = "spring-web-7.0.8.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/spring-web/7.0.8/spring-web-7.0.8.jar"
+packaging = "jar"
+root = false
+
+[[package.dependancies]]
+group = "org.springframework"
+artifact = "spring-beans"
+version = "7.0.8"
+
+[[package.dependancies]]
+group = "io.micrometer"
+artifact = "micrometer-observation"
+version = "1.16.6"
+
+[[package.dependancies]]
+group = "org.springframework"
+artifact = "spring-core"
+version = "7.0.8"
+
+[[package]]
+group = "org.springframework.boot"
+artifact = "spring-boot-starter-jackson"
+version = "4.1.0"
+file_name = "spring-boot-starter-jackson-4.1.0.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter-jackson/4.1.0/spring-boot-starter-jackson-4.1.0.jar"
+packaging = "jar"
+root = false
+
+[[package.dependancies]]
+group = "org.springframework.boot"
+artifact = "spring-boot-starter"
+version = "4.1.0"
+
+[[package.dependancies]]
+group = "org.springframework.boot"
+artifact = "spring-boot-jackson"
+version = "4.1.0"
+
+[[package]]
+group = "com.google.guava"
+artifact = "guava"
+version = "33.6.0-jre"
+file_name = "guava-33.6.0-jre.jar"
+url = "https://repo1.maven.org/maven2/com/google/guava/guava/33.6.0-jre/guava-33.6.0-jre.jar"
+packaging = "bundle"
+root = true
+
+[[package.dependancies]]
+group = "com.google.j2objc"
+artifact = "j2objc-annotations"
+version = "3.1"
+
+[[package.dependancies]]
+group = "org.jspecify"
+artifact = "jspecify"
+version = "1.0.0"
+
+[[package.dependancies]]
+group = "com.google.guava"
+artifact = "failureaccess"
+version = "1.0.3"
+
+[[package.dependancies]]
+group = "com.google.errorprone"
+artifact = "error_prone_annotations"
+version = "2.47.0"
+
+[[package.dependancies]]
+group = "com.google.guava"
+artifact = "listenablefuture"
+version = "9999.0-empty-to-avoid-conflict-with-guava"
+
+[[package]]
+group = "org.apache.logging.log4j"
+artifact = "log4j-to-slf4j"
+version = "2.25.4"
+file_name = "log4j-to-slf4j-2.25.4.jar"
+url = "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-to-slf4j/2.25.4/log4j-to-slf4j-2.25.4.jar"
+packaging = "jar"
+root = false
+
+[[package.dependancies]]
+group = "org.apache.logging.log4j"
+artifact = "log4j-api"
+version = "2.25.4"
+
+[[package]]
+group = "io.micrometer"
+artifact = "micrometer-commons"
+version = "1.16.6"
+file_name = "micrometer-commons-1.16.6.jar"
+url = "https://repo1.maven.org/maven2/io/micrometer/micrometer-commons/1.16.6/micrometer-commons-1.16.6.jar"
+packaging = "jar"
+root = false
+
+[[package.dependancies]]
+group = "org.jspecify"
+artifact = "jspecify"
+version = "1.0.0"
+
+[[package]]
+group = "org.springframework"
+artifact = "spring-beans"
+version = "7.0.8"
+file_name = "spring-beans-7.0.8.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/spring-beans/7.0.8/spring-beans-7.0.8.jar"
 dependancies = []
 packaging = "jar"
 root = false
 
 [[package]]
 group = "org.springframework.boot"
-artifact = "spring-boot-starter-web"
+artifact = "spring-boot-starter"
 version = "4.1.0"
-file_name = "spring-boot-starter-web-4.1.0.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter-web/4.1.0/spring-boot-starter-web-4.1.0.jar"
+file_name = "spring-boot-starter-4.1.0.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter/4.1.0/spring-boot-starter-4.1.0.jar"
 packaging = "jar"
-root = true
+root = false
 
 [[package.dependancies]]
 group = "org.springframework.boot"
-artifact = "spring-boot-http-converter"
+artifact = "spring-boot-autoconfigure"
 version = "4.1.0"
 
 [[package.dependancies]]
-group = "org.springframework.boot"
-artifact = "spring-boot-webmvc"
-version = "4.1.0"
+group = "org.yaml"
+artifact = "snakeyaml"
+version = "2.6"
+
+[[package.dependancies]]
+group = "jakarta.annotation"
+artifact = "jakarta.annotation-api"
+version = "3.0.0"
 
 [[package.dependancies]]
 group = "org.springframework.boot"
-artifact = "spring-boot-starter-tomcat"
-version = "4.1.0"
-
-[[package.dependancies]]
-group = "org.springframework.boot"
-artifact = "spring-boot-starter-jackson"
+artifact = "spring-boot-starter-logging"
 version = "4.1.0"
 
 [[package]]
 group = "org.springframework"
-artifact = "spring-expression"
+artifact = "spring-context"
 version = "7.0.8"
-file_name = "spring-expression-7.0.8.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/spring-expression/7.0.8/spring-expression-7.0.8.jar"
-dependancies = []
+file_name = "spring-context-7.0.8.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/spring-context/7.0.8/spring-context-7.0.8.jar"
 packaging = "jar"
 root = false
+
+[[package.dependancies]]
+group = "org.springframework"
+artifact = "spring-aop"
+version = "7.0.8"
+
+[[package.dependancies]]
+group = "org.springframework"
+artifact = "spring-beans"
+version = "7.0.8"
+
+[[package.dependancies]]
+group = "org.springframework"
+artifact = "spring-expression"
+version = "7.0.8"
 
 [[package]]
 group = "org.springframework.boot"
-artifact = "spring-boot-autoconfigure"
+artifact = "spring-boot-starter-tomcat"
 version = "4.1.0"
-file_name = "spring-boot-autoconfigure-4.1.0.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-autoconfigure/4.1.0/spring-boot-autoconfigure-4.1.0.jar"
-dependancies = []
+file_name = "spring-boot-starter-tomcat-4.1.0.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter-tomcat/4.1.0/spring-boot-starter-tomcat-4.1.0.jar"
 packaging = "jar"
 root = false
 
-[[package]]
-group = "org.apache.tomcat.embed"
-artifact = "tomcat-embed-websocket"
-version = "11.0.22"
-file_name = "tomcat-embed-websocket-11.0.22.jar"
-url = "https://repo1.maven.org/maven2/org/apache/tomcat/embed/tomcat-embed-websocket/11.0.22/tomcat-embed-websocket-11.0.22.jar"
-dependancies = []
-packaging = "jar"
-root = false
+[[package.dependancies]]
+group = "org.springframework.boot"
+artifact = "spring-boot-tomcat"
+version = "4.1.0"
+
+[[package.dependancies]]
+group = "org.springframework.boot"
+artifact = "spring-boot-starter-tomcat-runtime"
+version = "4.1.0"
+
+[[package.dependancies]]
+group = "org.springframework.boot"
+artifact = "spring-boot-starter"
+version = "4.1.0"
 
 [[package]]
 group = "org.springframework"
@@ -160,360 +668,14 @@ artifact = "spring-web"
 version = "7.0.8"
 
 [[package]]
-group = "org.springframework.boot"
-artifact = "spring-boot-starter-logging"
-version = "4.1.0"
-file_name = "spring-boot-starter-logging-4.1.0.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter-logging/4.1.0/spring-boot-starter-logging-4.1.0.jar"
-packaging = "jar"
-root = false
-
-[[package.dependancies]]
-group = "org.slf4j"
-artifact = "jul-to-slf4j"
-version = "2.0.18"
-
-[[package.dependancies]]
-group = "ch.qos.logback"
-artifact = "logback-classic"
-version = "1.5.34"
-
-[[package.dependancies]]
-group = "org.apache.logging.log4j"
-artifact = "log4j-to-slf4j"
-version = "2.25.4"
-
-[[package]]
-group = "org.springframework.boot"
-artifact = "spring-boot-starter-jackson"
-version = "4.1.0"
-file_name = "spring-boot-starter-jackson-4.1.0.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter-jackson/4.1.0/spring-boot-starter-jackson-4.1.0.jar"
-packaging = "jar"
-root = false
-
-[[package.dependancies]]
-group = "org.springframework.boot"
-artifact = "spring-boot-starter"
-version = "4.1.0"
-
-[[package.dependancies]]
-group = "org.springframework.boot"
-artifact = "spring-boot-jackson"
-version = "4.1.0"
-
-[[package]]
-group = "com.fasterxml.jackson.core"
-artifact = "jackson-annotations"
-version = "2.21"
-file_name = "jackson-annotations-2.21.jar"
-url = "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21.jar"
+group = "org.springframework"
+artifact = "spring-expression"
+version = "7.0.8"
+file_name = "spring-expression-7.0.8.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/spring-expression/7.0.8/spring-expression-7.0.8.jar"
 dependancies = []
 packaging = "jar"
 root = false
-
-[[package]]
-group = "org.apache.tomcat.embed"
-artifact = "tomcat-embed-el"
-version = "11.0.22"
-file_name = "tomcat-embed-el-11.0.22.jar"
-url = "https://repo1.maven.org/maven2/org/apache/tomcat/embed/tomcat-embed-el/11.0.22/tomcat-embed-el-11.0.22.jar"
-dependancies = []
-packaging = "jar"
-root = false
-
-[[package]]
-group = "org.springframework.boot"
-artifact = "spring-boot-http-converter"
-version = "4.1.0"
-file_name = "spring-boot-http-converter-4.1.0.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-http-converter/4.1.0/spring-boot-http-converter-4.1.0.jar"
-packaging = "jar"
-root = false
-
-[[package.dependancies]]
-group = "org.springframework"
-artifact = "spring-web"
-version = "7.0.8"
-
-[[package.dependancies]]
-group = "org.springframework.boot"
-artifact = "spring-boot"
-version = "4.1.0"
-
-[[package]]
-group = "org.slf4j"
-artifact = "jul-to-slf4j"
-version = "2.0.18"
-file_name = "jul-to-slf4j-2.0.18.jar"
-url = "https://repo1.maven.org/maven2/org/slf4j/jul-to-slf4j/2.0.18/jul-to-slf4j-2.0.18.jar"
-packaging = "jar"
-root = false
-
-[[package.dependancies]]
-group = "org.slf4j"
-artifact = "slf4j-api"
-version = "2.0.18"
-
-[[package]]
-group = "org.springframework"
-artifact = "spring-web"
-version = "7.0.8"
-file_name = "spring-web-7.0.8.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/spring-web/7.0.8/spring-web-7.0.8.jar"
-packaging = "jar"
-root = false
-
-[[package.dependancies]]
-group = "org.springframework"
-artifact = "spring-beans"
-version = "7.0.8"
-
-[[package.dependancies]]
-group = "io.micrometer"
-artifact = "micrometer-observation"
-version = "1.16.6"
-
-[[package.dependancies]]
-group = "org.springframework"
-artifact = "spring-core"
-version = "7.0.8"
-
-[[package]]
-group = "org.springframework.boot"
-artifact = "spring-boot-webmvc"
-version = "4.1.0"
-file_name = "spring-boot-webmvc-4.1.0.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-webmvc/4.1.0/spring-boot-webmvc-4.1.0.jar"
-packaging = "jar"
-root = false
-
-[[package.dependancies]]
-group = "org.springframework"
-artifact = "spring-web"
-version = "7.0.8"
-
-[[package.dependancies]]
-group = "org.springframework.boot"
-artifact = "spring-boot-servlet"
-version = "4.1.0"
-
-[[package.dependancies]]
-group = "org.springframework.boot"
-artifact = "spring-boot-http-converter"
-version = "4.1.0"
-
-[[package.dependancies]]
-group = "org.springframework"
-artifact = "spring-webmvc"
-version = "7.0.8"
-
-[[package]]
-group = "io.micrometer"
-artifact = "micrometer-commons"
-version = "1.16.6"
-file_name = "micrometer-commons-1.16.6.jar"
-url = "https://repo1.maven.org/maven2/io/micrometer/micrometer-commons/1.16.6/micrometer-commons-1.16.6.jar"
-packaging = "jar"
-root = false
-
-[[package.dependancies]]
-group = "org.jspecify"
-artifact = "jspecify"
-version = "1.0.0"
-
-[[package]]
-group = "org.springframework.boot"
-artifact = "spring-boot-web-server"
-version = "4.1.0"
-file_name = "spring-boot-web-server-4.1.0.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-web-server/4.1.0/spring-boot-web-server-4.1.0.jar"
-dependancies = []
-packaging = "jar"
-root = false
-
-[[package]]
-group = "org.springframework.boot"
-artifact = "spring-boot-jackson"
-version = "4.1.0"
-file_name = "spring-boot-jackson-4.1.0.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-jackson/4.1.0/spring-boot-jackson-4.1.0.jar"
-packaging = "jar"
-root = false
-
-[[package.dependancies]]
-group = "tools.jackson.core"
-artifact = "jackson-databind"
-version = "3.1.4"
-
-[[package]]
-group = "jakarta.annotation"
-artifact = "jakarta.annotation-api"
-version = "3.0.0"
-file_name = "jakarta.annotation-api-3.0.0.jar"
-url = "https://repo1.maven.org/maven2/jakarta/annotation/jakarta.annotation-api/3.0.0/jakarta.annotation-api-3.0.0.jar"
-dependancies = []
-packaging = "jar"
-root = false
-
-[[package]]
-group = "org.jspecify"
-artifact = "jspecify"
-version = "1.0.0"
-file_name = "jspecify-1.0.0.jar"
-url = "https://repo1.maven.org/maven2/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar"
-dependancies = []
-packaging = "jar"
-root = false
-
-[[package]]
-group = "ch.qos.logback"
-artifact = "logback-classic"
-version = "1.5.34"
-file_name = "logback-classic-1.5.34.jar"
-url = "https://repo1.maven.org/maven2/ch/qos/logback/logback-classic/1.5.34/logback-classic-1.5.34.jar"
-packaging = "jar"
-root = false
-
-[[package.dependancies]]
-group = "ch.qos.logback"
-artifact = "logback-core"
-version = "1.5.34"
-
-[[package]]
-group = "org.springframework.boot"
-artifact = "spring-boot"
-version = "4.1.0"
-file_name = "spring-boot-4.1.0.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot/4.1.0/spring-boot-4.1.0.jar"
-packaging = "jar"
-root = false
-
-[[package.dependancies]]
-group = "org.springframework"
-artifact = "spring-context"
-version = "7.0.8"
-
-[[package.dependancies]]
-group = "org.springframework"
-artifact = "spring-core"
-version = "7.0.8"
-
-[[package]]
-group = "org.springframework.boot"
-artifact = "spring-boot-servlet"
-version = "4.1.0"
-file_name = "spring-boot-servlet-4.1.0.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-servlet/4.1.0/spring-boot-servlet-4.1.0.jar"
-packaging = "jar"
-root = false
-
-[[package.dependancies]]
-group = "org.springframework.boot"
-artifact = "spring-boot"
-version = "4.1.0"
-
-[[package.dependancies]]
-group = "org.springframework"
-artifact = "spring-web"
-version = "7.0.8"
-
-[[package]]
-group = "org.springframework.boot"
-artifact = "spring-boot-tomcat"
-version = "4.1.0"
-file_name = "spring-boot-tomcat-4.1.0.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-tomcat/4.1.0/spring-boot-tomcat-4.1.0.jar"
-packaging = "jar"
-root = false
-
-[[package.dependancies]]
-group = "org.springframework.boot"
-artifact = "spring-boot-web-server"
-version = "4.1.0"
-
-[[package.dependancies]]
-group = "jakarta.annotation"
-artifact = "jakarta.annotation-api"
-version = "3.0.0"
-
-[[package.dependancies]]
-group = "org.apache.tomcat.embed"
-artifact = "tomcat-embed-core"
-version = "11.0.22"
-
-[[package]]
-group = "org.springframework"
-artifact = "spring-beans"
-version = "7.0.8"
-file_name = "spring-beans-7.0.8.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/spring-beans/7.0.8/spring-beans-7.0.8.jar"
-dependancies = []
-packaging = "jar"
-root = false
-
-[[package]]
-group = "org.apache.tomcat.embed"
-artifact = "tomcat-embed-core"
-version = "11.0.22"
-file_name = "tomcat-embed-core-11.0.22.jar"
-url = "https://repo1.maven.org/maven2/org/apache/tomcat/embed/tomcat-embed-core/11.0.22/tomcat-embed-core-11.0.22.jar"
-packaging = "jar"
-root = false
-
-[[package.dependancies]]
-group = "org.apache.tomcat"
-artifact = "tomcat-annotations-api"
-version = "11.0.22"
-
-[[package]]
-group = "org.apache.logging.log4j"
-artifact = "log4j-api"
-version = "2.25.4"
-file_name = "log4j-api-2.25.4.jar"
-url = "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.25.4/log4j-api-2.25.4.jar"
-dependancies = []
-packaging = "jar"
-root = false
-
-[[package]]
-group = "tools.jackson.core"
-artifact = "jackson-core"
-version = "3.1.4"
-file_name = "jackson-core-3.1.4.jar"
-url = "https://repo1.maven.org/maven2/tools/jackson/core/jackson-core/3.1.4/jackson-core-3.1.4.jar"
-dependancies = []
-packaging = "jar"
-root = false
-
-[[package]]
-group = "org.springframework.boot"
-artifact = "spring-boot-starter"
-version = "4.1.0"
-file_name = "spring-boot-starter-4.1.0.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter/4.1.0/spring-boot-starter-4.1.0.jar"
-packaging = "jar"
-root = false
-
-[[package.dependancies]]
-group = "org.springframework.boot"
-artifact = "spring-boot-autoconfigure"
-version = "4.1.0"
-
-[[package.dependancies]]
-group = "org.yaml"
-artifact = "snakeyaml"
-version = "2.6"
-
-[[package.dependancies]]
-group = "jakarta.annotation"
-artifact = "jakarta.annotation-api"
-version = "3.0.0"
-
-[[package.dependancies]]
-group = "org.springframework.boot"
-artifact = "spring-boot-starter-logging"
-version = "4.1.0"
 
 [[package]]
 group = "tools.jackson.core"
@@ -535,132 +697,44 @@ artifact = "jackson-annotations"
 version = "2.21"
 
 [[package]]
-group = "org.apache.tomcat"
-artifact = "tomcat-annotations-api"
-version = "11.0.22"
-file_name = "tomcat-annotations-api-11.0.22.jar"
-url = "https://repo1.maven.org/maven2/org/apache/tomcat/tomcat-annotations-api/11.0.22/tomcat-annotations-api-11.0.22.jar"
-dependancies = []
+group = "org.springframework.boot"
+artifact = "spring-boot-starter-web"
+version = "4.1.0"
+file_name = "spring-boot-starter-web-4.1.0.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter-web/4.1.0/spring-boot-starter-web-4.1.0.jar"
 packaging = "jar"
-root = false
+root = true
 
-[[package]]
-group = "org.yaml"
-artifact = "snakeyaml"
-version = "2.6"
-file_name = "snakeyaml-2.6.jar"
-url = "https://repo1.maven.org/maven2/org/yaml/snakeyaml/2.6/snakeyaml-2.6.jar"
-dependancies = []
-packaging = "bundle"
-root = false
+[[package.dependancies]]
+group = "org.springframework.boot"
+artifact = "spring-boot-http-converter"
+version = "4.1.0"
 
-[[package]]
-group = "org.slf4j"
-artifact = "slf4j-api"
-version = "2.0.18"
-file_name = "slf4j-api-2.0.18.jar"
-url = "https://repo1.maven.org/maven2/org/slf4j/slf4j-api/2.0.18/slf4j-api-2.0.18.jar"
-dependancies = []
-packaging = "jar"
-root = false
+[[package.dependancies]]
+group = "org.springframework.boot"
+artifact = "spring-boot-webmvc"
+version = "4.1.0"
 
-[[package]]
+[[package.dependancies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-starter-tomcat"
 version = "4.1.0"
-file_name = "spring-boot-starter-tomcat-4.1.0.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter-tomcat/4.1.0/spring-boot-starter-tomcat-4.1.0.jar"
-packaging = "jar"
-root = false
 
 [[package.dependancies]]
 group = "org.springframework.boot"
-artifact = "spring-boot-tomcat"
-version = "4.1.0"
-
-[[package.dependancies]]
-group = "org.springframework.boot"
-artifact = "spring-boot-starter-tomcat-runtime"
-version = "4.1.0"
-
-[[package.dependancies]]
-group = "org.springframework.boot"
-artifact = "spring-boot-starter"
+artifact = "spring-boot-starter-jackson"
 version = "4.1.0"
 
 [[package]]
-group = "org.apache.logging.log4j"
-artifact = "log4j-to-slf4j"
-version = "2.25.4"
-file_name = "log4j-to-slf4j-2.25.4.jar"
-url = "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-to-slf4j/2.25.4/log4j-to-slf4j-2.25.4.jar"
+group = "ch.qos.logback"
+artifact = "logback-classic"
+version = "1.5.34"
+file_name = "logback-classic-1.5.34.jar"
+url = "https://repo1.maven.org/maven2/ch/qos/logback/logback-classic/1.5.34/logback-classic-1.5.34.jar"
 packaging = "jar"
 root = false
 
 [[package.dependancies]]
-group = "org.apache.logging.log4j"
-artifact = "log4j-api"
-version = "2.25.4"
-
-[[package]]
-group = "org.springframework.boot"
-artifact = "spring-boot-starter-tomcat-runtime"
-version = "4.1.0"
-file_name = "spring-boot-starter-tomcat-runtime-4.1.0.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter-tomcat-runtime/4.1.0/spring-boot-starter-tomcat-runtime-4.1.0.jar"
-packaging = "jar"
-root = false
-
-[[package.dependancies]]
-group = "org.springframework.boot"
-artifact = "spring-boot-web-server"
-version = "4.1.0"
-
-[[package.dependancies]]
-group = "org.apache.tomcat.embed"
-artifact = "tomcat-embed-el"
-version = "11.0.22"
-
-[[package.dependancies]]
-group = "org.apache.tomcat.embed"
-artifact = "tomcat-embed-websocket"
-version = "11.0.22"
-
-[[package.dependancies]]
-group = "jakarta.annotation"
-artifact = "jakarta.annotation-api"
-version = "3.0.0"
-
-[[package.dependancies]]
-group = "org.apache.tomcat.embed"
-artifact = "tomcat-embed-core"
-version = "11.0.22"
-
-[[package]]
-group = "io.micrometer"
-artifact = "micrometer-observation"
-version = "1.16.6"
-file_name = "micrometer-observation-1.16.6.jar"
-url = "https://repo1.maven.org/maven2/io/micrometer/micrometer-observation/1.16.6/micrometer-observation-1.16.6.jar"
-packaging = "jar"
-root = false
-
-[[package.dependancies]]
-group = "io.micrometer"
-artifact = "micrometer-commons"
-version = "1.16.6"
-
-[[package.dependancies]]
-group = "org.jspecify"
-artifact = "jspecify"
-version = "1.0.0"
-
-[[package]]
-group = "commons-logging"
-artifact = "commons-logging"
-version = "1.3.5"
-file_name = "commons-logging-1.3.5.jar"
-url = "https://repo1.maven.org/maven2/commons-logging/commons-logging/1.3.5/commons-logging-1.3.5.jar"
-dependancies = []
-packaging = "jar"
-root = false
+group = "ch.qos.logback"
+artifact = "logback-core"
+version = "1.5.34"

--- a/test_filesystem/project/lazy-java.toml
+++ b/test_filesystem/project/lazy-java.toml
@@ -1,6 +1,8 @@
 dependancies = [
     "org.springframework.boot:spring-boot-starter-web:4.1.0",
-    "org.springframework.boot:spring-boot-starter-web:4.1.0",
+    "com.google.guava:guava:33.6.0-jre",
 ]
 
 [project]
+
+[setup]

--- a/test_filesystem/test2/.project
+++ b/test_filesystem/test2/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>test2</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+	<filteredResources>
+		<filter>
+			<id>1779043104810</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
+</projectDescription>


### PR DESCRIPTION
Closes #44.

### Summary

Introduces a `Context` struct as the single source of truth for project-wide state — paths (src/bin/lib/root), config, and global args — removing the need to fetch/reconstruct these values in every command handler.

### Changes

- **`src/context.rs`** — new `Context` struct with path resolution (CLI args > config > defaults), embedded `Config`, and individual assertions (`assert_src_exists`, `assert_bin_exists`, `assert_lib_exists`, `assert_build_lib_src`).
- **`src/lazy_java.rs`** — `LazyJava` is now a unit struct. `execute()` dispatches to `_internal` thin wrappers that create context, assert requirements, then call the implementation functions.
- **`src/config/config_structs.rs`** — added `[setup]` section with optional `lib`, `src`, `bin` paths.
- **All command files** — refactored to accept `&Context` instead of `&LazyJava`, eliminating repeated `Config::fetch` and path reconstruction.
- **`src/args.rs`** — `source`, `build`, `lib` changed from `String` to `Option<String>` (defaults handled by `Context`).
- **`src/utils/find_root.rs`** — root markers now include `lazy-java.toml`, `lazy-java.lock`, `.project`, `.classpath`.