### PR TITLE
Generate pom.xml from lock file for Maven interop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,6 +326,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +545,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1043,6 +1060,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1169,6 +1199,7 @@ dependencies = [
  "fs_extra",
  "globset",
  "inquire",
+ "insta",
  "log",
  "maven-version-rs",
  "parking_lot",
@@ -1977,6 +2008,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,4 @@ tempfile = "3.27.0"
 assert_cmd = "2"
 predicates = "3"
 fs_extra = "1.3"
+insta = { version = "1", features = ["yaml"] }

--- a/src/args.rs
+++ b/src/args.rs
@@ -52,6 +52,14 @@ pub enum LazyJavaCommand {
         #[command(flatten)]
         args: SyncArgs,
     },
+    Generate {
+        #[command(flatten)]
+        args: GenerateArgs,
+    },
+    Import {
+        #[command(flatten)]
+        args: ImportArgs,
+    },
 }
 #[derive(Debug, Parser, Clone)]
 pub struct RunArgs {
@@ -140,6 +148,41 @@ pub struct RemoveArgs {
 
 #[derive(Debug, Parser, Clone)]
 pub struct SyncArgs {}
+
+#[derive(Debug, Parser, Clone)]
+pub struct GenerateArgs {
+    #[command(subcommand)]
+    pub command: GenerateCommand,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum GenerateCommand {
+    Pom,
+}
+
+#[derive(Debug, Parser, Clone)]
+pub struct ImportArgs {
+    #[command(subcommand)]
+    pub command: ImportCommand,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum ImportCommand {
+    Pom {
+        #[command(flatten)]
+        args: ImportPomArgs,
+    },
+}
+#[derive(Parser, Debug, Clone)]
+pub struct ImportPomArgs {
+    /// Path to the pom.xml file to import
+    #[arg(long = "pom-path", default_value = "pom.xml")]
+    pub pom_path: String,
+
+    /// Overwrite existing lazy-java.toml if it exists
+    #[arg(long = "overwrite")]
+    pub overwrite: bool,
+}
 
 #[derive(Debug, Parser, Clone)]
 pub struct LazyJavaGlobalArgs {

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -32,9 +32,9 @@ impl Config {
             _ => ConfigError::NoConfig(root.join(CONFIG_FILE_NAME)),
         })?;
 
-        let lockfile: Config = toml::from_str(&file)?;
+        let config: Config = toml::from_str(&file)?;
 
-        Ok(lockfile)
+        Ok(config)
     }
     pub fn write(&self, root: &Path) -> Result<(), ConfigError> {
         let str = toml::to_string_pretty(self)?;

--- a/src/config/config_custom_serde.rs
+++ b/src/config/config_custom_serde.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error};
 
@@ -20,7 +20,7 @@ pub fn serialize_dependencies<S>(
 where
     S: Serializer,
 {
-    let mut map = HashMap::with_capacity(deps.len());
+    let mut map = BTreeMap::new();
 
     for (_key, dep) in deps {
         let entry = DependencyEntry {

--- a/src/context.rs
+++ b/src/context.rs
@@ -8,7 +8,8 @@ use decompose::decompose;
 
 use crate::{
     BUILD_FOLDER, LIB_FOLDER, SRC_FOLDER, TARGET_FOLDER, args::LazyJavaArgs, config::Config,
-    lazy_java_error::LazyJavaError, utils::find_root::find_root,
+    lazy_java_error::LazyJavaError, lock_file::LockFile, lsp::sync_lsp_config,
+    utils::find_root::find_root,
 };
 
 #[decompose(ContextNoConfig, exclude(config))]
@@ -198,6 +199,25 @@ impl Context {
         self.ensure_lib_exists()?;
         self.ensure_target_exists()?;
         Ok(())
+    }
+    pub fn assert_packages(self) -> Result<Context, LazyJavaError> {
+        let (inc, exc) = self.decompose();
+
+        let mut lockfile = LockFile::fetch(&inc.root)?;
+
+        exc.config.sync_lock_file(&mut lockfile, &inc)?;
+
+        if !inc.dry_run {
+            exc.config.write(&inc.root)?;
+        }
+
+        let ctx = Context::compose(inc, exc);
+
+        if !ctx.dry_run {
+            sync_lsp_config(&ctx)?;
+        }
+
+        Ok(ctx)
     }
     fn target_path<'a>(args: Option<&'a LazyJavaArgs>, config: &'a Config) -> &'a str {
         if args.is_some()

--- a/src/generate/generate.rs
+++ b/src/generate/generate.rs
@@ -1,0 +1,16 @@
+use crate::{
+    Context, LazyJava,
+    args::{GenerateArgs, GenerateCommand},
+    generate::pom::generate_pom,
+    lazy_java_error::LazyJavaError,
+};
+
+impl LazyJava {
+    pub fn generate(args: &GenerateArgs, ctx: &Context) -> Result<(), LazyJavaError> {
+        match args.command {
+            GenerateCommand::Pom => generate_pom(ctx)?,
+        }
+
+        Ok(())
+    }
+}

--- a/src/generate/generate_error.rs
+++ b/src/generate/generate_error.rs
@@ -1,0 +1,24 @@
+use std::io;
+
+use quick_xml::SeError;
+use thiserror::Error;
+
+use crate::lock_file::LockFileError;
+
+#[derive(Error, Debug)]
+pub enum GenerateError {
+    #[error("Field {value_name} required to generate {generated_value}")]
+    MissingValue {
+        value_name: &'static str,
+        generated_value: &'static str,
+    },
+
+    #[error("Error serializing")]
+    SerialError(#[from] SeError),
+
+    #[error("Error when operating on lock file")]
+    LockFileError(#[from] LockFileError),
+
+    #[error("An IO error occured")]
+    IOError(#[from] io::Error),
+}

--- a/src/generate/mod.rs
+++ b/src/generate/mod.rs
@@ -1,0 +1,6 @@
+mod generate_error;
+mod pom;
+
+pub mod generate;
+
+pub use generate_error::GenerateError;

--- a/src/generate/pom.rs
+++ b/src/generate/pom.rs
@@ -1,0 +1,124 @@
+use std::{collections::HashMap, fs};
+
+use colored::Colorize;
+use quick_xml::se::Serializer;
+use serde::Serialize;
+
+use crate::{
+    Context,
+    generate::GenerateError,
+    lock_file::LockFile,
+    maven_central::pom::{
+        AnnotationProcessorPaths, Build, Configuration, DependancyType, Dependencies, Dependency,
+        MavenPom, Plugin, Plugins, ProcessorPath, Properties, Scope,
+    },
+};
+
+pub fn generate_pom(ctx: &Context) -> Result<(), GenerateError> {
+    let pom = create_pom(ctx)?;
+    let mut buffer = String::new();
+
+    let mut serializer = Serializer::new(&mut buffer);
+    serializer.indent(' ', 4);
+
+    pom.serialize(serializer)?;
+
+    fs::write(ctx.root.join("pom.xml"), buffer)?;
+    println!("{} pom.xml", "Generated".green().bold());
+
+    return Ok(());
+}
+
+fn create_pom(ctx: &Context) -> Result<MavenPom, GenerateError> {
+    let group_id = assert(ctx.config.project.group.as_ref(), "group")?;
+    let artifact_id = assert(ctx.config.project.artifact.as_ref(), "artifact")?;
+    let version_id = assert(ctx.config.project.version.as_ref(), "version")?;
+
+    if !ctx.config.processors.is_empty() {
+        eprintln!(
+            "{} Local annotation processors are not supported in generated pom.xml. Only Maven-sourced processors are included.",
+            "Warning:".yellow().bold()
+        );
+    }
+
+    let lockfile = LockFile::fetch(&ctx.root)?;
+
+    let build = {
+        let processor_deps: Vec<_> = lockfile
+            .packages
+            .iter()
+            .filter(|p| !p.annotations.is_empty())
+            .collect();
+        if !processor_deps.is_empty() {
+            Some(Build {
+                plugins: Some(Plugins {
+                    plugin: vec![Plugin {
+                        group_id: Some("org.apache.maven.plugins".into()),
+                        artifact_id: Some("maven-compiler-plugin".into()),
+                        version: Some("3.11.0".into()),
+                        configuration: Some(Configuration {
+                            annotation_processor_paths: Some(AnnotationProcessorPaths {
+                                path: processor_deps
+                                    .into_iter()
+                                    .map(|p| ProcessorPath {
+                                        group_id: p.id.group.clone(),
+                                        artifact_id: p.id.artifact.clone(),
+                                        version: p.id.version.clone(),
+                                    })
+                                    .collect(),
+                            }),
+                        }),
+                    }],
+                }),
+                source: None,
+                target: None,
+            })
+        } else {
+            None
+        }
+    };
+
+    let mut dependancies: Vec<Dependency> = lockfile
+        .packages
+        .into_iter()
+        .filter(|d| d.root)
+        .map(|d| Dependency {
+            group_id: d.id.group,
+            artifact_id: d.id.artifact,
+            version: Some(d.id.version),
+            scope: Scope::Compile,
+            optional: false,
+            dependency_type: d.packaging,
+            classifier: None,
+        })
+        .collect();
+    dependancies.sort_by(|a, b| a.group_id.cmp(&b.group_id).then(a.artifact_id.cmp(&b.artifact_id)));
+    let dependancies = Dependencies {
+        dependency: dependancies,
+    };
+
+    Ok(MavenPom {
+        model_version: Some("4.0.0".into()),
+        group_id: group_id.to_string(),
+        artifact_id: artifact_id.to_string(),
+        version: version_id.to_string(),
+        packaging: DependancyType::Jar,
+        dependencies: Some(dependancies),
+        dependency_management: None,
+        properties: Properties {
+            map: HashMap::new(),
+        },
+        parent: None,
+        build,
+        dependency_management_map: HashMap::new(),
+    })
+}
+fn assert<'a, T>(value: Option<&'a T>, value_name: &'static str) -> Result<&'a T, GenerateError> {
+    match value {
+        Some(v) => Ok(v),
+        None => Err(GenerateError::MissingValue {
+            value_name: value_name,
+            generated_value: "pom.xml",
+        }),
+    }
+}

--- a/src/import/import.rs
+++ b/src/import/import.rs
@@ -1,0 +1,22 @@
+use std::env;
+
+use crate::{
+    LazyJava,
+    args::{ImportArgs, ImportCommand},
+    import::{ImportError, pom::import_pom},
+    lazy_java_error::LazyJavaError,
+};
+
+impl LazyJava {
+    pub fn import(args: &ImportArgs) -> Result<(), LazyJavaError> {
+        let res: Result<(), ImportError> = match &args.command {
+            ImportCommand::Pom { args } => {
+                let root = env::current_dir()?;
+
+                import_pom(&root, args)
+            }
+        };
+
+        Ok(res?)
+    }
+}

--- a/src/import/import_error.rs
+++ b/src/import/import_error.rs
@@ -1,0 +1,15 @@
+use std::io;
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ImportError {
+    #[error("Could not read pom.xml")]
+    IOError(#[from] io::Error),
+
+    #[error("Could not parse pom.xml")]
+    ParseError(#[from] quick_xml::DeError),
+
+    #[error("Could not serialize config")]
+    SerializeError(#[from] toml::ser::Error),
+}

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -1,0 +1,8 @@
+mod import_error;
+pub mod import;
+pub mod pom;
+
+#[cfg(test)]
+mod tests;
+
+pub use import_error::ImportError;

--- a/src/import/pom.rs
+++ b/src/import/pom.rs
@@ -1,0 +1,94 @@
+use std::{
+    collections::HashMap,
+    fs,
+    hash::{DefaultHasher, Hash, Hasher},
+    path::Path,
+};
+
+use colored::Colorize;
+
+use crate::{
+    args::ImportPomArgs,
+    config::{Config, ConfigDependancy, ConfigProject},
+    maven_central::{MavenIdBuf, PartialMavenIdBuf, pom::MavenPom},
+};
+
+use super::ImportError;
+
+fn dep_mgmt_map(pom: &MavenPom) -> HashMap<u64, String> {
+    let mut map = HashMap::new();
+    if let Some(mgmt) = &pom.dependency_management {
+        for dep in &mgmt.dependencies.dependency {
+            if let Some(version) = &dep.version {
+                let mut hasher = DefaultHasher::new();
+                (dep.group_id.as_str(), dep.artifact_id.as_str()).hash(&mut hasher);
+                map.insert(hasher.finish(), version.clone());
+            }
+        }
+    }
+    map
+}
+
+pub fn import_pom(root: &Path, args: &ImportPomArgs) -> Result<(), ImportError> {
+    let toml_path = root.join("lazy-java.toml");
+    if toml_path.exists() && !args.overwrite {
+        eprintln!(
+            "{} lazy-java.toml already exists. Use --overwrite to replace it.",
+            "Skipping:".yellow().bold()
+        );
+        return Ok(());
+    }
+
+    let content = fs::read_to_string(&root.join(&args.pom_path))?;
+    let pom: MavenPom = quick_xml::de::from_str(&content)?;
+
+    let mgmt_map = dep_mgmt_map(&pom);
+
+    let mut dependancies: Vec<(PartialMavenIdBuf, ConfigDependancy)> = Vec::new();
+    if let Some(deps) = &pom.dependencies {
+        for dep in &deps.dependency {
+            let version = match &dep.version {
+                Some(v) => v.clone(),
+                None => {
+                    let mut hasher = DefaultHasher::new();
+                    (dep.group_id.as_str(), dep.artifact_id.as_str()).hash(&mut hasher);
+                    match mgmt_map.get(&hasher.finish()) {
+                        Some(v) => v.clone(),
+                        None => {
+                            eprintln!(
+                                "{} Skipping {}:{} — no version in dep or dependencyManagement",
+                                "Warning:".yellow().bold(),
+                                dep.group_id,
+                                dep.artifact_id,
+                            );
+                            continue;
+                        }
+                    }
+                }
+            };
+            let key = PartialMavenIdBuf::new(&dep.group_id, &dep.artifact_id);
+            dependancies.push((
+                key,
+                MavenIdBuf::new(&dep.group_id, &dep.artifact_id, version).into(),
+            ));
+        }
+    }
+    let dependancies: HashMap<_, _> = dependancies.into_iter().collect();
+
+    let config = Config {
+        project: ConfigProject {
+            name: pom.artifact_id.clone(),
+            group: Some(pom.group_id.clone()),
+            artifact: Some(pom.artifact_id.clone()),
+            version: Some(pom.version.clone()),
+        },
+        dependancies,
+        ..Default::default()
+    };
+
+    let toml_str = toml::to_string_pretty(&config)?;
+    fs::write(root.join("lazy-java.toml"), toml_str)?;
+    println!("{} lazy-java.toml from pom.xml", "Imported".green().bold());
+
+    Ok(())
+}

--- a/src/import/tests.rs
+++ b/src/import/tests.rs
@@ -1,0 +1,62 @@
+use std::fs;
+
+use super::pom::import_pom;
+use crate::args::ImportPomArgs;
+
+#[test]
+fn existing_toml_without_overwrite_is_preserved() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    fs::write(root.join("pom.xml"), r#"<project>
+        <groupId>com.example</groupId>
+        <artifactId>test</artifactId>
+        <version>1.0</version>
+    </project>"#)
+    .unwrap();
+
+    fs::write(root.join("lazy-java.toml"), r#"[project]
+name = "original""#)
+    .unwrap();
+
+    import_pom(
+        root,
+        &ImportPomArgs {
+            pom_path: "pom.xml".into(),
+            overwrite: false,
+        },
+    )
+    .unwrap();
+
+    let content = fs::read_to_string(root.join("lazy-java.toml")).unwrap();
+    assert!(content.contains("original"), "should not overwrite");
+}
+
+#[test]
+fn existing_toml_with_overwrite_flag_is_replaced() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    fs::write(root.join("pom.xml"), r#"<project>
+        <groupId>com.example</groupId>
+        <artifactId>test</artifactId>
+        <version>1.0</version>
+    </project>"#)
+    .unwrap();
+
+    fs::write(root.join("lazy-java.toml"), r#"[project]
+name = "original""#)
+    .unwrap();
+
+    import_pom(
+        root,
+        &ImportPomArgs {
+            pom_path: "pom.xml".into(),
+            overwrite: true,
+        },
+    )
+    .unwrap();
+
+    let content = fs::read_to_string(root.join("lazy-java.toml")).unwrap();
+    assert!(content.contains("test"), "should overwrite with pom data");
+}

--- a/src/lazy_java.rs
+++ b/src/lazy_java.rs
@@ -1,8 +1,8 @@
 use crate::{
     Context,
     args::{
-        AddArgs, BuildCommand, FindArgs, LazyJavaArgs, LazyJavaCommand, RemoveArgs, RunArgs,
-        SyncArgs,
+        AddArgs, BuildCommand, FindArgs, GenerateArgs, ImportArgs, LazyJavaArgs, LazyJavaCommand,
+        RemoveArgs, RunArgs, SyncArgs,
     },
     config::Config,
     lazy_java_error::LazyJavaError,
@@ -20,12 +20,27 @@ impl LazyJava {
             LazyJavaCommand::Add { args } => Self::add_internal(&cli_args, args),
             LazyJavaCommand::Remove { args } => Self::remove_internal(&cli_args, args),
             LazyJavaCommand::Sync { args } => Self::sync_internal(&cli_args, args),
+            LazyJavaCommand::Generate { args } => Self::generate_internal(&cli_args, args),
+            LazyJavaCommand::Import { args } => Self::import_internal(&cli_args, args),
         }
+    }
+    fn import_internal(_all_args: &LazyJavaArgs, args: &ImportArgs) -> Result<(), LazyJavaError> {
+        Self::import(args)
+    }
+    fn generate_internal(
+        all_args: &LazyJavaArgs,
+        args: &GenerateArgs,
+    ) -> Result<(), LazyJavaError> {
+        let ctx = Context::new(all_args)?;
+        ctx.assert_all()?;
+        let ctx = ctx.assert_packages()?;
+        Self::generate(args, &ctx)
     }
 
     fn build_internal(all_args: &LazyJavaArgs, args: &BuildCommand) -> Result<(), LazyJavaError> {
         let ctx = Context::new(all_args)?;
         ctx.assert_all()?;
+        let ctx = ctx.assert_packages()?;
         Self::build(args, &ctx)
     }
 
@@ -44,6 +59,7 @@ impl LazyJava {
     fn run_internal(all_args: &LazyJavaArgs, args: &RunArgs) -> Result<(), LazyJavaError> {
         let ctx = Context::new(all_args)?;
         ctx.assert_all()?;
+        let ctx = ctx.assert_packages()?;
         Self::run(args, &ctx)
     }
 

--- a/src/lazy_java_error.rs
+++ b/src/lazy_java_error.rs
@@ -4,11 +4,16 @@ use thiserror::Error;
 
 use crate::{
     build::GraphError, config::ConfigError, create::create_project::CreateProjectError,
-    lock_file::LockFileError, lsp::classpath_error::ClasspathError, maven_central::MavenError,
+    generate::GenerateError, import::ImportError, lock_file::LockFileError,
+    lsp::classpath_error::ClasspathError, maven_central::MavenError,
 };
 
 #[derive(Error, Debug)]
 pub enum LazyJavaError {
+    #[error("Could not generate value")]
+    GenerateError(#[from] GenerateError),
+    #[error("Could not import value")]
+    ImportError(#[from] ImportError),
     #[error("Could not create project")]
     CreateError(#[from] CreateProjectError),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ pub mod config;
 mod context;
 pub mod create;
 pub mod find;
+pub mod generate;
+pub mod import;
 mod lazy_java;
 pub mod lazy_java_error;
 pub mod lock_file;

--- a/src/lock_file/lock_file.rs
+++ b/src/lock_file/lock_file.rs
@@ -17,7 +17,7 @@ use crate::{
     lock_file::LockFileError,
     maven_central::{
         MavenId, MavenIdBuf, PartialMavenIdBuf,
-        pom::{DependancyType, MavenDependancyList},
+        pom::{DependancyType, MavenDependancyList, Scope},
     },
 };
 
@@ -41,6 +41,7 @@ pub struct LockFilePackage {
     pub packaging: DependancyType,
 
     pub root: bool,
+    pub scope: Scope,
 
     #[serde(default)]
     pub annotations: Vec<String>,
@@ -134,7 +135,11 @@ impl LockFile {
         map: &mut HashMap<String, &mut LockFilePackage>,
         dry_run: bool,
     ) -> Result<isize, LockFileError> {
-        println!("    {} {}", "Validating".green().bold(), path.display());
+        println!(
+            "    {} {}",
+            "Validating".green().bold(),
+            path.file_stem().unwrap().display()
+        );
         let mut removed = 0;
         for file in walkdir::WalkDir::new(path)
             .into_iter()

--- a/src/lock_file/remove_tests.rs
+++ b/src/lock_file/remove_tests.rs
@@ -22,6 +22,7 @@ mod tests {
             dependancies: dep_ids,
             packaging: DependancyType::Jar,
             root: false,
+            scope: crate::maven_central::pom::Scope::Compile,
             annotations: Vec::new(),
         }
     }

--- a/src/maven_central/pom/dependancy_list.rs
+++ b/src/maven_central/pom/dependancy_list.rs
@@ -196,6 +196,7 @@ impl MavenDependancyList {
                 dependancy_type: pom.packaging.clone(),
                 dependancies: dependancy_list,
                 root: false,
+                scope: Scope::Compile,
             });
         }
 

--- a/src/maven_central/pom/dependancy_list_structs.rs
+++ b/src/maven_central/pom/dependancy_list_structs.rs
@@ -7,7 +7,7 @@ use crate::{
     maven_central::{
         MavenIdBuf,
         fetch::full_maven_url,
-        pom::{DependancyType, MavenPom},
+        pom::{DependancyType, MavenPom, Scope},
     },
 };
 
@@ -26,6 +26,7 @@ pub struct MavenDependancy {
     pub id: MavenIdBuf,
     pub dependancy_type: DependancyType,
     pub dependancies: Vec<Dependancy>,
+    pub scope: Scope,
     pub root: bool,
 }
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -54,6 +55,7 @@ impl From<MavenDependancy> for LockFilePackage {
             dependancies: value.dependancies.into_iter().map(|v| v.id).collect(),
             root: value.root,
             annotations: Vec::new(),
+            scope: value.scope,
         }
     }
 }

--- a/src/maven_central/pom/pom.rs
+++ b/src/maven_central/pom/pom.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use strum::AsRefStr;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename = "project")]
 pub struct MavenPom {
     #[serde(rename = "modelVersion")]
@@ -23,31 +23,38 @@ pub struct MavenPom {
 
     pub dependencies: Option<Dependencies>,
 
-    #[serde(rename = "dependencyManagement")]
+    #[serde(
+        rename = "dependencyManagement",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub dependency_management: Option<DependencyManagement>,
 
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_default")]
     pub properties: Properties,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub parent: Option<Parent>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub build: Option<Build>,
 
     #[serde(skip)]
     pub dependency_management_map: HashMap<u64, String>,
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize, Default, Serialize)]
 pub struct Dependencies {
     #[serde(rename = "dependency", default)]
     pub dependency: Vec<Dependency>,
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize, Default, Serialize)]
 pub struct DependencyManagement {
     #[serde(default)]
     pub dependencies: Dependencies,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Dependency {
     #[serde(rename = "groupId")]
     pub group_id: String,
@@ -55,6 +62,7 @@ pub struct Dependency {
     #[serde(rename = "artifactId")]
     pub artifact_id: String,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
 
     #[serde(default)]
@@ -66,14 +74,17 @@ pub struct Dependency {
     #[serde(rename = "type", default)]
     pub dependency_type: DependancyType,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub classifier: Option<String>,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
 pub struct Properties {
     pub map: HashMap<String, String>,
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Hash, Default)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Hash, Default, PartialOrd, Ord,
+)]
 #[serde(rename_all = "lowercase")]
 pub enum Scope {
     #[default]
@@ -122,7 +133,7 @@ impl<'de> Deserialize<'de> for DependancyType {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Parent {
     #[serde(rename = "groupId")]
     pub group_id: String,
@@ -133,4 +144,61 @@ pub struct Parent {
     pub version: String,
 
     pub relative_path: Option<String>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct Build {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plugins: Option<Plugins>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct Plugins {
+    #[serde(rename = "plugin", default)]
+    pub plugin: Vec<Plugin>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct Plugin {
+    #[serde(rename = "groupId", skip_serializing_if = "Option::is_none")]
+    pub group_id: Option<String>,
+    #[serde(rename = "artifactId", skip_serializing_if = "Option::is_none")]
+    pub artifact_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub configuration: Option<Configuration>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Configuration {
+    #[serde(
+        rename = "annotationProcessorPaths",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub annotation_processor_paths: Option<AnnotationProcessorPaths>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AnnotationProcessorPaths {
+    #[serde(rename = "path", default)]
+    pub path: Vec<ProcessorPath>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ProcessorPath {
+    #[serde(rename = "groupId")]
+    pub group_id: String,
+    #[serde(rename = "artifactId")]
+    pub artifact_id: String,
+    pub version: String,
+}
+
+fn is_default<T: Default + PartialEq>(value: &T) -> bool {
+    value == &T::default()
 }

--- a/src/maven_central/pom/pom_deserialize.rs
+++ b/src/maven_central/pom/pom_deserialize.rs
@@ -12,7 +12,7 @@ impl MavenPom {
 
         pom.group_id = id.group.to_string();
         pom.version = id.version.to_string();
-
+        //
         // creates the dependency_management_map
         pom.dependency_management_map = match &pom.dependency_management {
             Some(boms) => boms

--- a/src/maven_central/pom/tests.rs
+++ b/src/maven_central/pom/tests.rs
@@ -3,7 +3,10 @@ mod tests {
 
     use crate::maven_central::{
         MavenIdBuf,
-        pom::{MavenDependancyList, dependancy_list_structs::MavenDependancy, pom::DependancyType},
+        pom::{
+            MavenDependancyList, dependancy_list_structs::MavenDependancy, pom::DependancyType,
+            pom::Scope,
+        },
     };
     #[test]
     fn init_logger() {
@@ -89,18 +92,21 @@ mod tests {
                 dependancy_type: DependancyType::Bundle,
                 dependancies: Vec::new(),
                 root: true,
+                scope: Scope::Compile,
             },
             MavenDependancy {
                 id: MavenIdBuf::new("com.google.errorprone", "error_prone_annotations", "2.47.0"),
                 dependancy_type: DependancyType::Jar,
                 dependancies: Vec::new(),
                 root: false,
+                scope: Scope::Compile,
             },
             MavenDependancy {
                 id: MavenIdBuf::new("com.google.guava", "failureaccess", "1.0.3"),
                 dependancy_type: DependancyType::Jar,
                 dependancies: Vec::new(),
                 root: false,
+                scope: Scope::Compile,
             },
             MavenDependancy {
                 id: MavenIdBuf::new(
@@ -111,18 +117,21 @@ mod tests {
                 dependancy_type: DependancyType::Jar,
                 dependancies: Vec::new(),
                 root: false,
+                scope: Scope::Compile,
             },
             MavenDependancy {
                 id: MavenIdBuf::new("com.google.j2objc", "j2objc-annotations", "3.1"),
                 dependancy_type: DependancyType::Jar,
                 dependancies: Vec::new(),
                 root: false,
+                scope: Scope::Compile,
             },
             MavenDependancy {
                 id: MavenIdBuf::new("org.jspecify", "jspecify", "1.0.0"),
                 dependancy_type: DependancyType::Jar,
                 dependancies: Vec::new(),
                 root: false,
+                scope: Scope::Compile,
             },
         ];
         expected.sort();

--- a/src/packages/sync_packages.rs
+++ b/src/packages/sync_packages.rs
@@ -21,7 +21,9 @@ impl LazyJava {
 
         exc.config.sync_lock_file(&mut lockfile, &inc)?;
 
-        exc.config.write(&inc.root)?;
+        if !inc.dry_run {
+            exc.config.write(&inc.root)?;
+        }
 
         let ctx = Context::compose(inc, exc);
 

--- a/test_filesystem/test10/lazy-java.lock
+++ b/test_filesystem/test10/lazy-java.lock
@@ -1,63 +1,77 @@
 [[package]]
-group = "org.springframework.boot"
-artifact = "spring-boot-starter-web"
-version = "4.1.0"
-file_name = "spring-boot-starter-web-4.1.0.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter-web/4.1.0/spring-boot-starter-web-4.1.0.jar"
+group = "org.apache.tomcat.embed"
+artifact = "tomcat-embed-core"
+version = "11.0.22"
+file_name = "tomcat-embed-core-11.0.22.jar"
+url = "https://repo1.maven.org/maven2/org/apache/tomcat/embed/tomcat-embed-core/11.0.22/tomcat-embed-core-11.0.22.jar"
 packaging = "jar"
-root = true
+root = false
+scope = "compile"
+annotations = []
+
+[[package.dependancies]]
+group = "org.apache.tomcat"
+artifact = "tomcat-annotations-api"
+version = "11.0.22"
+
+[[package]]
+group = "org.springframework.boot"
+artifact = "spring-boot-tomcat"
+version = "4.1.0"
+file_name = "spring-boot-tomcat-4.1.0.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-tomcat/4.1.0/spring-boot-tomcat-4.1.0.jar"
+packaging = "jar"
+root = false
+scope = "compile"
 annotations = []
 
 [[package.dependancies]]
 group = "org.springframework.boot"
-artifact = "spring-boot-http-converter"
+artifact = "spring-boot-web-server"
 version = "4.1.0"
 
 [[package.dependancies]]
-group = "org.springframework.boot"
-artifact = "spring-boot-webmvc"
-version = "4.1.0"
+group = "jakarta.annotation"
+artifact = "jakarta.annotation-api"
+version = "3.0.0"
 
 [[package.dependancies]]
-group = "org.springframework.boot"
-artifact = "spring-boot-starter-jackson"
-version = "4.1.0"
-
-[[package.dependancies]]
-group = "org.springframework.boot"
-artifact = "spring-boot-starter-tomcat"
-version = "4.1.0"
+group = "org.apache.tomcat.embed"
+artifact = "tomcat-embed-core"
+version = "11.0.22"
 
 [[package]]
-group = "org.springframework.boot"
-artifact = "spring-boot-autoconfigure"
-version = "4.1.0"
-file_name = "spring-boot-autoconfigure-4.1.0.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-autoconfigure/4.1.0/spring-boot-autoconfigure-4.1.0.jar"
+group = "tools.jackson.core"
+artifact = "jackson-core"
+version = "3.1.4"
+file_name = "jackson-core-3.1.4.jar"
+url = "https://repo1.maven.org/maven2/tools/jackson/core/jackson-core/3.1.4/jackson-core-3.1.4.jar"
 dependancies = []
 packaging = "jar"
 root = false
+scope = "compile"
 annotations = []
 
 [[package]]
 group = "org.springframework.boot"
-artifact = "spring-boot-starter-jackson"
+artifact = "spring-boot"
 version = "4.1.0"
-file_name = "spring-boot-starter-jackson-4.1.0.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter-jackson/4.1.0/spring-boot-starter-jackson-4.1.0.jar"
+file_name = "spring-boot-4.1.0.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot/4.1.0/spring-boot-4.1.0.jar"
 packaging = "jar"
 root = false
+scope = "compile"
 annotations = []
 
 [[package.dependancies]]
-group = "org.springframework.boot"
-artifact = "spring-boot-jackson"
-version = "4.1.0"
+group = "org.springframework"
+artifact = "spring-context"
+version = "7.0.8"
 
 [[package.dependancies]]
-group = "org.springframework.boot"
-artifact = "spring-boot-starter"
-version = "4.1.0"
+group = "org.springframework"
+artifact = "spring-core"
+version = "7.0.8"
 
 [[package]]
 group = "org.springframework"
@@ -68,93 +82,75 @@ url = "https://repo1.maven.org/maven2/org/springframework/spring-expression/7.0.
 dependancies = []
 packaging = "jar"
 root = false
-annotations = []
-
-[[package]]
-group = "org.springframework"
-artifact = "spring-aop"
-version = "7.0.8"
-file_name = "spring-aop-7.0.8.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/spring-aop/7.0.8/spring-aop-7.0.8.jar"
-packaging = "jar"
-root = false
-annotations = []
-
-[[package.dependancies]]
-group = "org.springframework"
-artifact = "spring-beans"
-version = "7.0.8"
-
-[[package]]
-group = "org.apache.tomcat"
-artifact = "tomcat-annotations-api"
-version = "11.0.22"
-file_name = "tomcat-annotations-api-11.0.22.jar"
-url = "https://repo1.maven.org/maven2/org/apache/tomcat/tomcat-annotations-api/11.0.22/tomcat-annotations-api-11.0.22.jar"
-dependancies = []
-packaging = "jar"
-root = false
-annotations = []
-
-[[package]]
-group = "org.springframework"
-artifact = "spring-context"
-version = "7.0.8"
-file_name = "spring-context-7.0.8.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/spring-context/7.0.8/spring-context-7.0.8.jar"
-packaging = "jar"
-root = false
-annotations = []
-
-[[package.dependancies]]
-group = "org.springframework"
-artifact = "spring-expression"
-version = "7.0.8"
-
-[[package.dependancies]]
-group = "org.springframework"
-artifact = "spring-aop"
-version = "7.0.8"
-
-[[package.dependancies]]
-group = "org.springframework"
-artifact = "spring-beans"
-version = "7.0.8"
-
-[[package]]
-group = "com.fasterxml.jackson.core"
-artifact = "jackson-annotations"
-version = "2.21"
-file_name = "jackson-annotations-2.21.jar"
-url = "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21.jar"
-dependancies = []
-packaging = "jar"
-root = false
+scope = "compile"
 annotations = []
 
 [[package]]
 group = "org.springframework.boot"
-artifact = "spring-boot-starter-logging"
+artifact = "spring-boot-autoconfigure"
 version = "4.1.0"
-file_name = "spring-boot-starter-logging-4.1.0.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter-logging/4.1.0/spring-boot-starter-logging-4.1.0.jar"
+file_name = "spring-boot-autoconfigure-4.1.0.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-autoconfigure/4.1.0/spring-boot-autoconfigure-4.1.0.jar"
+dependancies = []
 packaging = "jar"
 root = false
+scope = "compile"
+annotations = []
+
+[[package]]
+group = "commons-logging"
+artifact = "commons-logging"
+version = "1.3.5"
+file_name = "commons-logging-1.3.5.jar"
+url = "https://repo1.maven.org/maven2/commons-logging/commons-logging/1.3.5/commons-logging-1.3.5.jar"
+dependancies = []
+packaging = "jar"
+root = false
+scope = "compile"
+annotations = []
+
+[[package]]
+group = "org.slf4j"
+artifact = "slf4j-api"
+version = "2.0.18"
+file_name = "slf4j-api-2.0.18.jar"
+url = "https://repo1.maven.org/maven2/org/slf4j/slf4j-api/2.0.18/slf4j-api-2.0.18.jar"
+dependancies = []
+packaging = "jar"
+root = false
+scope = "compile"
+annotations = []
+
+[[package]]
+group = "org.slf4j"
+artifact = "jul-to-slf4j"
+version = "2.0.18"
+file_name = "jul-to-slf4j-2.0.18.jar"
+url = "https://repo1.maven.org/maven2/org/slf4j/jul-to-slf4j/2.0.18/jul-to-slf4j-2.0.18.jar"
+packaging = "jar"
+root = false
+scope = "compile"
 annotations = []
 
 [[package.dependancies]]
 group = "org.slf4j"
-artifact = "jul-to-slf4j"
+artifact = "slf4j-api"
 version = "2.0.18"
 
-[[package.dependancies]]
-group = "ch.qos.logback"
-artifact = "logback-classic"
-version = "1.5.34"
+[[package]]
+group = "org.apache.logging.log4j"
+artifact = "log4j-to-slf4j"
+version = "2.25.4"
+file_name = "log4j-to-slf4j-2.25.4.jar"
+url = "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-to-slf4j/2.25.4/log4j-to-slf4j-2.25.4.jar"
+packaging = "jar"
+root = false
+scope = "compile"
+annotations = []
 
 [[package.dependancies]]
 group = "org.apache.logging.log4j"
-artifact = "log4j-to-slf4j"
+artifact = "log4j-api"
 version = "2.25.4"
 
 [[package]]
@@ -166,6 +162,7 @@ url = "https://repo1.maven.org/maven2/org/jspecify/jspecify/1.0.0/jspecify-1.0.0
 dependancies = []
 packaging = "jar"
 root = false
+scope = "compile"
 annotations = []
 
 [[package]]
@@ -176,6 +173,7 @@ file_name = "spring-boot-http-converter-4.1.0.jar"
 url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-http-converter/4.1.0/spring-boot-http-converter-4.1.0.jar"
 packaging = "jar"
 root = false
+scope = "compile"
 annotations = []
 
 [[package.dependancies]]
@@ -196,277 +194,46 @@ file_name = "spring-boot-webmvc-4.1.0.jar"
 url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-webmvc/4.1.0/spring-boot-webmvc-4.1.0.jar"
 packaging = "jar"
 root = false
+scope = "compile"
 annotations = []
 
 [[package.dependancies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-servlet"
 version = "4.1.0"
-
-[[package.dependancies]]
-group = "org.springframework"
-artifact = "spring-webmvc"
-version = "7.0.8"
 
 [[package.dependancies]]
 group = "org.springframework"
 artifact = "spring-web"
 version = "7.0.8"
 
-[[package]]
-group = "org.springframework.boot"
-artifact = "spring-boot-tomcat"
-version = "4.1.0"
-file_name = "spring-boot-tomcat-4.1.0.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-tomcat/4.1.0/spring-boot-tomcat-4.1.0.jar"
-packaging = "jar"
-root = false
-annotations = []
-
 [[package.dependancies]]
-group = "org.springframework.boot"
-artifact = "spring-boot-web-server"
-version = "4.1.0"
-
-[[package.dependancies]]
-group = "org.apache.tomcat.embed"
-artifact = "tomcat-embed-core"
-version = "11.0.22"
-
-[[package.dependancies]]
-group = "jakarta.annotation"
-artifact = "jakarta.annotation-api"
-version = "3.0.0"
+group = "org.springframework"
+artifact = "spring-webmvc"
+version = "7.0.8"
 
 [[package]]
-group = "org.springframework.boot"
-artifact = "spring-boot-servlet"
-version = "4.1.0"
-file_name = "spring-boot-servlet-4.1.0.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-servlet/4.1.0/spring-boot-servlet-4.1.0.jar"
-dependancies = []
-packaging = "jar"
-root = false
-annotations = []
-
-[[package]]
-group = "commons-logging"
-artifact = "commons-logging"
-version = "1.3.5"
-file_name = "commons-logging-1.3.5.jar"
-url = "https://repo1.maven.org/maven2/commons-logging/commons-logging/1.3.5/commons-logging-1.3.5.jar"
-dependancies = []
-packaging = "jar"
-root = false
-annotations = []
-
-[[package]]
-group = "tools.jackson.core"
-artifact = "jackson-databind"
-version = "3.1.4"
-file_name = "jackson-databind-3.1.4.jar"
-url = "https://repo1.maven.org/maven2/tools/jackson/core/jackson-databind/3.1.4/jackson-databind-3.1.4.jar"
-packaging = "jar"
-root = false
-annotations = []
-
-[[package.dependancies]]
-group = "tools.jackson.core"
-artifact = "jackson-core"
-version = "3.1.4"
-
-[[package.dependancies]]
-group = "com.fasterxml.jackson.core"
-artifact = "jackson-annotations"
-version = "2.21"
-
-[[package]]
-group = "ch.qos.logback"
-artifact = "logback-classic"
-version = "1.5.34"
-file_name = "logback-classic-1.5.34.jar"
-url = "https://repo1.maven.org/maven2/ch/qos/logback/logback-classic/1.5.34/logback-classic-1.5.34.jar"
-packaging = "jar"
-root = false
-annotations = []
-
-[[package.dependancies]]
-group = "ch.qos.logback"
-artifact = "logback-core"
-version = "1.5.34"
-
-[[package]]
-group = "org.springframework.boot"
-artifact = "spring-boot-starter"
-version = "4.1.0"
-file_name = "spring-boot-starter-4.1.0.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter/4.1.0/spring-boot-starter-4.1.0.jar"
-packaging = "jar"
-root = false
-annotations = []
-
-[[package.dependancies]]
 group = "org.yaml"
 artifact = "snakeyaml"
 version = "2.6"
-
-[[package.dependancies]]
-group = "org.springframework.boot"
-artifact = "spring-boot-autoconfigure"
-version = "4.1.0"
-
-[[package.dependancies]]
-group = "jakarta.annotation"
-artifact = "jakarta.annotation-api"
-version = "3.0.0"
-
-[[package.dependancies]]
-group = "org.springframework.boot"
-artifact = "spring-boot-starter-logging"
-version = "4.1.0"
-
-[[package]]
-group = "com.google.auto.value"
-artifact = "auto-value-annotations"
-version = "1.11.1"
-file_name = "auto-value-annotations-1.11.1.jar"
-url = "https://repo1.maven.org/maven2/com/google/auto/value/auto-value-annotations/1.11.1/auto-value-annotations-1.11.1.jar"
+file_name = "snakeyaml-2.6.jar"
+url = "https://repo1.maven.org/maven2/org/yaml/snakeyaml/2.6/snakeyaml-2.6.jar"
 dependancies = []
-packaging = "jar"
-root = true
-annotations = []
-
-[[package]]
-group = "org.springframework.boot"
-artifact = "spring-boot-starter-tomcat"
-version = "4.1.0"
-file_name = "spring-boot-starter-tomcat-4.1.0.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter-tomcat/4.1.0/spring-boot-starter-tomcat-4.1.0.jar"
-packaging = "jar"
+packaging = "bundle"
 root = false
+scope = "compile"
 annotations = []
 
-[[package.dependancies]]
-group = "org.springframework.boot"
-artifact = "spring-boot-tomcat"
-version = "4.1.0"
-
-[[package.dependancies]]
-group = "org.springframework.boot"
-artifact = "spring-boot-starter-tomcat-runtime"
-version = "4.1.0"
-
-[[package.dependancies]]
-group = "org.springframework.boot"
-artifact = "spring-boot-starter"
-version = "4.1.0"
-
 [[package]]
-group = "org.apache.tomcat.embed"
-artifact = "tomcat-embed-core"
-version = "11.0.22"
-file_name = "tomcat-embed-core-11.0.22.jar"
-url = "https://repo1.maven.org/maven2/org/apache/tomcat/embed/tomcat-embed-core/11.0.22/tomcat-embed-core-11.0.22.jar"
-packaging = "jar"
-root = false
-annotations = []
-
-[[package.dependancies]]
-group = "org.apache.tomcat"
-artifact = "tomcat-annotations-api"
-version = "11.0.22"
-
-[[package]]
-group = "org.springframework"
-artifact = "spring-webmvc"
-version = "7.0.8"
-file_name = "spring-webmvc-7.0.8.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/spring-webmvc/7.0.8/spring-webmvc-7.0.8.jar"
-packaging = "jar"
-root = false
-annotations = []
-
-[[package.dependancies]]
-group = "org.springframework"
-artifact = "spring-beans"
-version = "7.0.8"
-
-[[package.dependancies]]
-group = "org.springframework"
-artifact = "spring-aop"
-version = "7.0.8"
-
-[[package.dependancies]]
-group = "org.springframework"
-artifact = "spring-expression"
-version = "7.0.8"
-
-[[package.dependancies]]
-group = "org.springframework"
-artifact = "spring-context"
-version = "7.0.8"
-
-[[package.dependancies]]
-group = "org.springframework"
-artifact = "spring-core"
-version = "7.0.8"
-
-[[package]]
-group = "org.apache.tomcat.embed"
-artifact = "tomcat-embed-el"
-version = "11.0.22"
-file_name = "tomcat-embed-el-11.0.22.jar"
-url = "https://repo1.maven.org/maven2/org/apache/tomcat/embed/tomcat-embed-el/11.0.22/tomcat-embed-el-11.0.22.jar"
+group = "org.springframework.boot"
+artifact = "spring-boot-web-server"
+version = "4.1.0"
+file_name = "spring-boot-web-server-4.1.0.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-web-server/4.1.0/spring-boot-web-server-4.1.0.jar"
 dependancies = []
 packaging = "jar"
 root = false
-annotations = []
-
-[[package]]
-group = "org.slf4j"
-artifact = "slf4j-api"
-version = "2.0.18"
-file_name = "slf4j-api-2.0.18.jar"
-url = "https://repo1.maven.org/maven2/org/slf4j/slf4j-api/2.0.18/slf4j-api-2.0.18.jar"
-dependancies = []
-packaging = "jar"
-root = false
-annotations = []
-
-[[package]]
-group = "org.springframework"
-artifact = "spring-web"
-version = "7.0.8"
-file_name = "spring-web-7.0.8.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/spring-web/7.0.8/spring-web-7.0.8.jar"
-packaging = "jar"
-root = false
-annotations = []
-
-[[package.dependancies]]
-group = "io.micrometer"
-artifact = "micrometer-observation"
-version = "1.16.6"
-
-[[package.dependancies]]
-group = "org.springframework"
-artifact = "spring-beans"
-version = "7.0.8"
-
-[[package.dependancies]]
-group = "org.springframework"
-artifact = "spring-core"
-version = "7.0.8"
-
-[[package]]
-group = "ch.qos.logback"
-artifact = "logback-core"
-version = "1.5.34"
-file_name = "logback-core-1.5.34.jar"
-url = "https://repo1.maven.org/maven2/ch/qos/logback/logback-core/1.5.34/logback-core-1.5.34.jar"
-dependancies = []
-packaging = "jar"
-root = false
+scope = "compile"
 annotations = []
 
 [[package]]
@@ -478,6 +245,7 @@ url = "https://repo1.maven.org/maven2/com/google/auto/value/auto-value/1.11.1/au
 dependancies = []
 packaging = "jar"
 root = true
+scope = "compile"
 annotations = [
     "com.google.auto.value.extension.memoized.processor.MemoizedValidator",
     "com.google.auto.value.extension.toprettystring.processor.ToPrettyStringValidator",
@@ -496,6 +264,7 @@ file_name = "spring-boot-starter-tomcat-runtime-4.1.0.jar"
 url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter-tomcat-runtime/4.1.0/spring-boot-starter-tomcat-runtime-4.1.0.jar"
 packaging = "jar"
 root = false
+scope = "compile"
 annotations = []
 
 [[package.dependancies]]
@@ -514,36 +283,66 @@ artifact = "tomcat-embed-el"
 version = "11.0.22"
 
 [[package.dependancies]]
+group = "jakarta.annotation"
+artifact = "jakarta.annotation-api"
+version = "3.0.0"
+
+[[package.dependancies]]
 group = "org.apache.tomcat.embed"
 artifact = "tomcat-embed-core"
 version = "11.0.22"
+
+[[package]]
+group = "tools.jackson.core"
+artifact = "jackson-databind"
+version = "3.1.4"
+file_name = "jackson-databind-3.1.4.jar"
+url = "https://repo1.maven.org/maven2/tools/jackson/core/jackson-databind/3.1.4/jackson-databind-3.1.4.jar"
+packaging = "jar"
+root = false
+scope = "compile"
+annotations = []
+
+[[package.dependancies]]
+group = "tools.jackson.core"
+artifact = "jackson-core"
+version = "3.1.4"
+
+[[package.dependancies]]
+group = "com.fasterxml.jackson.core"
+artifact = "jackson-annotations"
+version = "2.21"
+
+[[package]]
+group = "org.springframework.boot"
+artifact = "spring-boot-starter"
+version = "4.1.0"
+file_name = "spring-boot-starter-4.1.0.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter/4.1.0/spring-boot-starter-4.1.0.jar"
+packaging = "jar"
+root = false
+scope = "compile"
+annotations = []
+
+[[package.dependancies]]
+group = "org.springframework.boot"
+artifact = "spring-boot-autoconfigure"
+version = "4.1.0"
+
+[[package.dependancies]]
+group = "org.yaml"
+artifact = "snakeyaml"
+version = "2.6"
 
 [[package.dependancies]]
 group = "jakarta.annotation"
 artifact = "jakarta.annotation-api"
 version = "3.0.0"
 
-[[package]]
-group = "jakarta.annotation"
-artifact = "jakarta.annotation-api"
-version = "3.0.0"
-file_name = "jakarta.annotation-api-3.0.0.jar"
-url = "https://repo1.maven.org/maven2/jakarta/annotation/jakarta.annotation-api/3.0.0/jakarta.annotation-api-3.0.0.jar"
-dependancies = []
-packaging = "jar"
-root = false
-annotations = []
-
-[[package]]
-group = "tools.jackson.core"
-artifact = "jackson-core"
-version = "3.1.4"
-file_name = "jackson-core-3.1.4.jar"
-url = "https://repo1.maven.org/maven2/tools/jackson/core/jackson-core/3.1.4/jackson-core-3.1.4.jar"
-dependancies = []
-packaging = "jar"
-root = false
-annotations = []
+[[package.dependancies]]
+group = "org.springframework.boot"
+artifact = "spring-boot-starter-logging"
+version = "4.1.0"
 
 [[package]]
 group = "org.springframework"
@@ -553,6 +352,7 @@ file_name = "spring-core-7.0.8.jar"
 url = "https://repo1.maven.org/maven2/org/springframework/spring-core/7.0.8/spring-core-7.0.8.jar"
 packaging = "jar"
 root = false
+scope = "compile"
 annotations = []
 
 [[package.dependancies]]
@@ -566,14 +366,46 @@ artifact = "commons-logging"
 version = "1.3.5"
 
 [[package]]
-group = "org.yaml"
-artifact = "snakeyaml"
-version = "2.6"
-file_name = "snakeyaml-2.6.jar"
-url = "https://repo1.maven.org/maven2/org/yaml/snakeyaml/2.6/snakeyaml-2.6.jar"
+group = "org.springframework.boot"
+artifact = "spring-boot-starter-web"
+version = "4.1.0"
+file_name = "spring-boot-starter-web-4.1.0.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter-web/4.1.0/spring-boot-starter-web-4.1.0.jar"
+packaging = "jar"
+root = true
+scope = "compile"
+annotations = []
+
+[[package.dependancies]]
+group = "org.springframework.boot"
+artifact = "spring-boot-webmvc"
+version = "4.1.0"
+
+[[package.dependancies]]
+group = "org.springframework.boot"
+artifact = "spring-boot-http-converter"
+version = "4.1.0"
+
+[[package.dependancies]]
+group = "org.springframework.boot"
+artifact = "spring-boot-starter-tomcat"
+version = "4.1.0"
+
+[[package.dependancies]]
+group = "org.springframework.boot"
+artifact = "spring-boot-starter-jackson"
+version = "4.1.0"
+
+[[package]]
+group = "org.apache.tomcat.embed"
+artifact = "tomcat-embed-el"
+version = "11.0.22"
+file_name = "tomcat-embed-el-11.0.22.jar"
+url = "https://repo1.maven.org/maven2/org/apache/tomcat/embed/tomcat-embed-el/11.0.22/tomcat-embed-el-11.0.22.jar"
 dependancies = []
-packaging = "bundle"
+packaging = "jar"
 root = false
+scope = "compile"
 annotations = []
 
 [[package]]
@@ -585,6 +417,284 @@ url = "https://repo1.maven.org/maven2/org/springframework/spring-beans/7.0.8/spr
 dependancies = []
 packaging = "jar"
 root = false
+scope = "compile"
+annotations = []
+
+[[package]]
+group = "org.springframework.boot"
+artifact = "spring-boot-starter-logging"
+version = "4.1.0"
+file_name = "spring-boot-starter-logging-4.1.0.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter-logging/4.1.0/spring-boot-starter-logging-4.1.0.jar"
+packaging = "jar"
+root = false
+scope = "compile"
+annotations = []
+
+[[package.dependancies]]
+group = "org.slf4j"
+artifact = "jul-to-slf4j"
+version = "2.0.18"
+
+[[package.dependancies]]
+group = "ch.qos.logback"
+artifact = "logback-classic"
+version = "1.5.34"
+
+[[package.dependancies]]
+group = "org.apache.logging.log4j"
+artifact = "log4j-to-slf4j"
+version = "2.25.4"
+
+[[package]]
+group = "org.springframework"
+artifact = "spring-web"
+version = "7.0.8"
+file_name = "spring-web-7.0.8.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/spring-web/7.0.8/spring-web-7.0.8.jar"
+packaging = "jar"
+root = false
+scope = "compile"
+annotations = []
+
+[[package.dependancies]]
+group = "org.springframework"
+artifact = "spring-beans"
+version = "7.0.8"
+
+[[package.dependancies]]
+group = "io.micrometer"
+artifact = "micrometer-observation"
+version = "1.16.6"
+
+[[package.dependancies]]
+group = "org.springframework"
+artifact = "spring-core"
+version = "7.0.8"
+
+[[package]]
+group = "org.springframework"
+artifact = "spring-aop"
+version = "7.0.8"
+file_name = "spring-aop-7.0.8.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/spring-aop/7.0.8/spring-aop-7.0.8.jar"
+packaging = "jar"
+root = false
+scope = "compile"
+annotations = []
+
+[[package.dependancies]]
+group = "org.springframework"
+artifact = "spring-beans"
+version = "7.0.8"
+
+[[package]]
+group = "org.springframework.boot"
+artifact = "spring-boot-jackson"
+version = "4.1.0"
+file_name = "spring-boot-jackson-4.1.0.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-jackson/4.1.0/spring-boot-jackson-4.1.0.jar"
+packaging = "jar"
+root = false
+scope = "compile"
+annotations = []
+
+[[package.dependancies]]
+group = "tools.jackson.core"
+artifact = "jackson-databind"
+version = "3.1.4"
+
+[[package]]
+group = "ch.qos.logback"
+artifact = "logback-classic"
+version = "1.5.34"
+file_name = "logback-classic-1.5.34.jar"
+url = "https://repo1.maven.org/maven2/ch/qos/logback/logback-classic/1.5.34/logback-classic-1.5.34.jar"
+packaging = "jar"
+root = false
+scope = "compile"
+annotations = []
+
+[[package.dependancies]]
+group = "ch.qos.logback"
+artifact = "logback-core"
+version = "1.5.34"
+
+[[package]]
+group = "io.micrometer"
+artifact = "micrometer-commons"
+version = "1.16.6"
+file_name = "micrometer-commons-1.16.6.jar"
+url = "https://repo1.maven.org/maven2/io/micrometer/micrometer-commons/1.16.6/micrometer-commons-1.16.6.jar"
+packaging = "jar"
+root = false
+scope = "compile"
+annotations = []
+
+[[package.dependancies]]
+group = "org.jspecify"
+artifact = "jspecify"
+version = "1.0.0"
+
+[[package]]
+group = "org.springframework.boot"
+artifact = "spring-boot-starter-tomcat"
+version = "4.1.0"
+file_name = "spring-boot-starter-tomcat-4.1.0.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter-tomcat/4.1.0/spring-boot-starter-tomcat-4.1.0.jar"
+packaging = "jar"
+root = false
+scope = "compile"
+annotations = []
+
+[[package.dependancies]]
+group = "org.springframework.boot"
+artifact = "spring-boot-tomcat"
+version = "4.1.0"
+
+[[package.dependancies]]
+group = "org.springframework.boot"
+artifact = "spring-boot-starter-tomcat-runtime"
+version = "4.1.0"
+
+[[package.dependancies]]
+group = "org.springframework.boot"
+artifact = "spring-boot-starter"
+version = "4.1.0"
+
+[[package]]
+group = "org.apache.tomcat"
+artifact = "tomcat-annotations-api"
+version = "11.0.22"
+file_name = "tomcat-annotations-api-11.0.22.jar"
+url = "https://repo1.maven.org/maven2/org/apache/tomcat/tomcat-annotations-api/11.0.22/tomcat-annotations-api-11.0.22.jar"
+dependancies = []
+packaging = "jar"
+root = false
+scope = "compile"
+annotations = []
+
+[[package]]
+group = "org.springframework.boot"
+artifact = "spring-boot-servlet"
+version = "4.1.0"
+file_name = "spring-boot-servlet-4.1.0.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-servlet/4.1.0/spring-boot-servlet-4.1.0.jar"
+dependancies = []
+packaging = "jar"
+root = false
+scope = "compile"
+annotations = []
+
+[[package]]
+group = "org.springframework.boot"
+artifact = "spring-boot-starter-jackson"
+version = "4.1.0"
+file_name = "spring-boot-starter-jackson-4.1.0.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter-jackson/4.1.0/spring-boot-starter-jackson-4.1.0.jar"
+packaging = "jar"
+root = false
+scope = "compile"
+annotations = []
+
+[[package.dependancies]]
+group = "org.springframework.boot"
+artifact = "spring-boot-jackson"
+version = "4.1.0"
+
+[[package.dependancies]]
+group = "org.springframework.boot"
+artifact = "spring-boot-starter"
+version = "4.1.0"
+
+[[package]]
+group = "org.apache.logging.log4j"
+artifact = "log4j-api"
+version = "2.25.4"
+file_name = "log4j-api-2.25.4.jar"
+url = "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.25.4/log4j-api-2.25.4.jar"
+dependancies = []
+packaging = "jar"
+root = false
+scope = "compile"
+annotations = []
+
+[[package]]
+group = "org.springframework"
+artifact = "spring-context"
+version = "7.0.8"
+file_name = "spring-context-7.0.8.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/spring-context/7.0.8/spring-context-7.0.8.jar"
+packaging = "jar"
+root = false
+scope = "compile"
+annotations = []
+
+[[package.dependancies]]
+group = "org.springframework"
+artifact = "spring-beans"
+version = "7.0.8"
+
+[[package.dependancies]]
+group = "org.springframework"
+artifact = "spring-expression"
+version = "7.0.8"
+
+[[package]]
+group = "com.google.auto.value"
+artifact = "auto-value-annotations"
+version = "1.11.1"
+file_name = "auto-value-annotations-1.11.1.jar"
+url = "https://repo1.maven.org/maven2/com/google/auto/value/auto-value-annotations/1.11.1/auto-value-annotations-1.11.1.jar"
+dependancies = []
+packaging = "jar"
+root = true
+scope = "compile"
+annotations = []
+
+[[package]]
+group = "com.fasterxml.jackson.core"
+artifact = "jackson-annotations"
+version = "2.21"
+file_name = "jackson-annotations-2.21.jar"
+url = "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21.jar"
+dependancies = []
+packaging = "jar"
+root = false
+scope = "compile"
+annotations = []
+
+[[package]]
+group = "io.micrometer"
+artifact = "micrometer-observation"
+version = "1.16.6"
+file_name = "micrometer-observation-1.16.6.jar"
+url = "https://repo1.maven.org/maven2/io/micrometer/micrometer-observation/1.16.6/micrometer-observation-1.16.6.jar"
+packaging = "jar"
+root = false
+scope = "compile"
+annotations = []
+
+[[package.dependancies]]
+group = "org.jspecify"
+artifact = "jspecify"
+version = "1.0.0"
+
+[[package.dependancies]]
+group = "io.micrometer"
+artifact = "micrometer-commons"
+version = "1.16.6"
+
+[[package]]
+group = "jakarta.annotation"
+artifact = "jakarta.annotation-api"
+version = "3.0.0"
+file_name = "jakarta.annotation-api-3.0.0.jar"
+url = "https://repo1.maven.org/maven2/jakarta/annotation/jakarta.annotation-api/3.0.0/jakarta.annotation-api-3.0.0.jar"
+dependancies = []
+packaging = "jar"
+root = false
+scope = "compile"
 annotations = []
 
 [[package]]
@@ -596,93 +706,46 @@ url = "https://repo1.maven.org/maven2/org/apache/tomcat/embed/tomcat-embed-webso
 dependancies = []
 packaging = "jar"
 root = false
+scope = "compile"
 annotations = []
 
 [[package]]
-group = "io.micrometer"
-artifact = "micrometer-commons"
-version = "1.16.6"
-file_name = "micrometer-commons-1.16.6.jar"
-url = "https://repo1.maven.org/maven2/io/micrometer/micrometer-commons/1.16.6/micrometer-commons-1.16.6.jar"
-packaging = "jar"
-root = false
-annotations = []
-
-[[package.dependancies]]
-group = "org.jspecify"
-artifact = "jspecify"
-version = "1.0.0"
-
-[[package]]
-group = "org.apache.logging.log4j"
-artifact = "log4j-to-slf4j"
-version = "2.25.4"
-file_name = "log4j-to-slf4j-2.25.4.jar"
-url = "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-to-slf4j/2.25.4/log4j-to-slf4j-2.25.4.jar"
-packaging = "jar"
-root = false
-annotations = []
-
-[[package.dependancies]]
-group = "org.apache.logging.log4j"
-artifact = "log4j-api"
-version = "2.25.4"
-
-[[package]]
-group = "org.slf4j"
-artifact = "jul-to-slf4j"
-version = "2.0.18"
-file_name = "jul-to-slf4j-2.0.18.jar"
-url = "https://repo1.maven.org/maven2/org/slf4j/jul-to-slf4j/2.0.18/jul-to-slf4j-2.0.18.jar"
-packaging = "jar"
-root = false
-annotations = []
-
-[[package.dependancies]]
-group = "org.slf4j"
-artifact = "slf4j-api"
-version = "2.0.18"
-
-[[package]]
-group = "io.micrometer"
-artifact = "micrometer-observation"
-version = "1.16.6"
-file_name = "micrometer-observation-1.16.6.jar"
-url = "https://repo1.maven.org/maven2/io/micrometer/micrometer-observation/1.16.6/micrometer-observation-1.16.6.jar"
-packaging = "jar"
-root = false
-annotations = []
-
-[[package.dependancies]]
-group = "io.micrometer"
-artifact = "micrometer-commons"
-version = "1.16.6"
-
-[[package.dependancies]]
-group = "org.jspecify"
-artifact = "jspecify"
-version = "1.0.0"
-
-[[package]]
-group = "org.springframework.boot"
-artifact = "spring-boot-web-server"
-version = "4.1.0"
-file_name = "spring-boot-web-server-4.1.0.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-web-server/4.1.0/spring-boot-web-server-4.1.0.jar"
+group = "ch.qos.logback"
+artifact = "logback-core"
+version = "1.5.34"
+file_name = "logback-core-1.5.34.jar"
+url = "https://repo1.maven.org/maven2/ch/qos/logback/logback-core/1.5.34/logback-core-1.5.34.jar"
 dependancies = []
 packaging = "jar"
 root = false
+scope = "compile"
 annotations = []
 
 [[package]]
-group = "org.springframework.boot"
-artifact = "spring-boot"
-version = "4.1.0"
-file_name = "spring-boot-4.1.0.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot/4.1.0/spring-boot-4.1.0.jar"
+group = "org.springframework"
+artifact = "spring-webmvc"
+version = "7.0.8"
+file_name = "spring-webmvc-7.0.8.jar"
+url = "https://repo1.maven.org/maven2/org/springframework/spring-webmvc/7.0.8/spring-webmvc-7.0.8.jar"
 packaging = "jar"
 root = false
+scope = "compile"
 annotations = []
+
+[[package.dependancies]]
+group = "org.springframework"
+artifact = "spring-beans"
+version = "7.0.8"
+
+[[package.dependancies]]
+group = "org.springframework"
+artifact = "spring-expression"
+version = "7.0.8"
+
+[[package.dependancies]]
+group = "org.springframework"
+artifact = "spring-aop"
+version = "7.0.8"
 
 [[package.dependancies]]
 group = "org.springframework"
@@ -693,34 +756,3 @@ version = "7.0.8"
 group = "org.springframework"
 artifact = "spring-core"
 version = "7.0.8"
-
-[[package]]
-group = "org.springframework.boot"
-artifact = "spring-boot-jackson"
-version = "4.1.0"
-file_name = "spring-boot-jackson-4.1.0.jar"
-url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-jackson/4.1.0/spring-boot-jackson-4.1.0.jar"
-packaging = "jar"
-root = false
-annotations = []
-
-[[package.dependancies]]
-group = "org.springframework.boot"
-artifact = "spring-boot"
-version = "4.1.0"
-
-[[package.dependancies]]
-group = "tools.jackson.core"
-artifact = "jackson-databind"
-version = "3.1.4"
-
-[[package]]
-group = "org.apache.logging.log4j"
-artifact = "log4j-api"
-version = "2.25.4"
-file_name = "log4j-api-2.25.4.jar"
-url = "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.25.4/log4j-api-2.25.4.jar"
-dependancies = []
-packaging = "jar"
-root = false
-annotations = []

--- a/test_filesystem/test10/lazy-java.toml
+++ b/test_filesystem/test10/lazy-java.toml
@@ -1,11 +1,20 @@
 [project]
 name = "test10"
+group = "group1"
+artifact = "artifact"
+version = "1.0.0"
+
+[processors.Annot]
+kind = "annotation"
+path = "./src/processor/Annot.java"
+package = "processor"
+
+[processors.ProcessorImpl]
+kind = "processor"
+path = "./src/processor/ProcessorImpl.java"
+package = "processor"
 
 [dependancies]
 spring-boot-starter-web= { group = "org.springframework.boot", version = "4.1.0" }
 auto-value-annotations= { group = "com.google.auto.value", version = "1.11.1" }
 auto-value= { group = "com.google.auto.value", version = "1.11.1" }
-
-[processors]
-Annot = { path = "./src/processor/Annot.java", kind = "annotation", package = "processor"}
-ProcessorImpl = { path = "./src/processor/ProcessorImpl.java", kind = "processor", package = "processor"}

--- a/test_filesystem/test10/target/.lazy-java-build
+++ b/test_filesystem/test10/target/.lazy-java-build
@@ -1,8 +1,8 @@
 java_version = "25"
 lib_hash = 16884585949925654684
-bin_hash = 8133405800211605323
+bin_hash = 17898127156720694965
 build_passed = true
 
 [time_stamp]
-secs_since_epoch = 1784499829
-nanos_since_epoch = 756148000
+secs_since_epoch = 1785016542
+nanos_since_epoch = 645806000

--- a/tests/fixtures/generate-pom/lazy-java.toml
+++ b/tests/fixtures/generate-pom/lazy-java.toml
@@ -1,0 +1,5 @@
+[project]
+name = "generate-pom"
+group = "com.example"
+artifact = "generate-pom"
+version = "2.0.0"

--- a/tests/fixtures/generate-pom/src/Main.java
+++ b/tests/fixtures/generate-pom/src/Main.java
@@ -1,0 +1,5 @@
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("generate pom test");
+    }
+}

--- a/tests/fixtures/import-pom/pom.xml
+++ b/tests/fixtures/import-pom/pom.xml
@@ -1,0 +1,19 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>my-library</artifactId>
+    <version>1.2.3</version>
+    <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>33.0.0-jre</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/generate_pom_test.rs
+++ b/tests/generate_pom_test.rs
@@ -1,0 +1,55 @@
+use assert_cmd::Command;
+use std::path::Path;
+
+fn fixture_path() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("generate-pom")
+}
+
+#[test]
+fn generate_pom_includes_deps_and_annotation_processors() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let dest = tmp.path().join("project");
+
+    fs_extra::dir::copy(
+        fixture_path(),
+        &dest,
+        &fs_extra::dir::CopyOptions::new().content_only(true),
+    )?;
+
+    let mut cmd = Command::cargo_bin("lazy-java")?;
+    cmd.current_dir(&dest);
+    cmd.args(["add", "org.apache.commons", "commons-lang3"]);
+    cmd.assert().success();
+
+    let mut cmd = Command::cargo_bin("lazy-java")?;
+    cmd.current_dir(&dest);
+    cmd.args(["add", "com.google.auto.value", "auto-value-annotations"]);
+    cmd.assert().success();
+
+    let mut cmd = Command::cargo_bin("lazy-java")?;
+    cmd.current_dir(&dest);
+    cmd.args(["add", "com.google.auto.value", "auto-value"]);
+    cmd.assert().success();
+
+    assert!(
+        dest.join("lazy-java.lock").exists(),
+        "lock file should exist after add"
+    );
+
+    let mut cmd = Command::cargo_bin("lazy-java")?;
+    cmd.current_dir(&dest);
+    cmd.args(["generate", "pom"]);
+    cmd.assert().success();
+
+    let pom_path = dest.join("pom.xml");
+    assert!(pom_path.exists(), "pom.xml should exist");
+
+    let pom_content = std::fs::read_to_string(pom_path)?;
+
+    insta::assert_snapshot!("generate_pom_output", pom_content);
+
+    Ok(())
+}

--- a/tests/import_pom_test.rs
+++ b/tests/import_pom_test.rs
@@ -1,0 +1,35 @@
+use assert_cmd::Command;
+use std::path::Path;
+
+fn fixture_path() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("import-pom")
+}
+
+#[test]
+fn import_pom_creates_lazy_java_toml() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let dest = tmp.path().join("project");
+
+    fs_extra::dir::copy(
+        fixture_path(),
+        &dest,
+        &fs_extra::dir::CopyOptions::new().content_only(true),
+    )?;
+
+    let mut cmd = Command::cargo_bin("lazy-java")?;
+    cmd.current_dir(&dest);
+    cmd.args(["import", "pom"]);
+    cmd.assert().success();
+
+    let toml_path = dest.join("lazy-java.toml");
+    assert!(toml_path.exists(), "lazy-java.toml should exist");
+
+    let toml_content = std::fs::read_to_string(toml_path)?;
+
+    insta::assert_snapshot!("import_pom_output", toml_content);
+
+    Ok(())
+}

--- a/tests/snapshots/generate_pom_test__generate_pom_output.snap
+++ b/tests/snapshots/generate_pom_test__generate_pom_output.snap
@@ -1,8 +1,13 @@
+---
+source: tests/generate_pom_test.rs
+assertion_line: 52
+expression: pom_content
+---
 <project>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>group1</groupId>
-    <artifactId>artifact</artifactId>
-    <version>1.0.0</version>
+    <groupId>com.example</groupId>
+    <artifactId>generate-pom</artifactId>
+    <version>2.0.0</version>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>
@@ -14,17 +19,17 @@
             <type>jar</type>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-            <version>4.1.0</version>
+            <groupId>com.google.auto.value</groupId>
+            <artifactId>auto-value-annotations</artifactId>
+            <version>1.11.1</version>
             <scope>compile</scope>
             <optional>false</optional>
             <type>jar</type>
         </dependency>
         <dependency>
-            <groupId>com.google.auto.value</groupId>
-            <artifactId>auto-value-annotations</artifactId>
-            <version>1.11.1</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.20.0</version>
             <scope>compile</scope>
             <optional>false</optional>
             <type>jar</type>

--- a/tests/snapshots/import_pom_test__import_pom_output.snap
+++ b/tests/snapshots/import_pom_test__import_pom_output.snap
@@ -1,0 +1,18 @@
+---
+source: tests/import_pom_test.rs
+assertion_line: 32
+expression: toml_content
+---
+[project]
+name = "my-library"
+group = "com.example"
+artifact = "my-library"
+version = "1.2.3"
+
+[dependancies.commons-lang3]
+group = "org.apache.commons"
+version = "3.12.0"
+
+[dependancies.guava]
+group = "com.google.guava"
+version = "33.0.0-jre"


### PR DESCRIPTION
Implements generating pom.xml from lazy-java.lock and importing pom.xml to create lazy-java.toml.

- `lazy-java generate pom` — reads lock file, produces pom.xml with dependencies and annotation processor paths
- `lazy-java import pom` — reads pom.xml, resolves dependency management, writes lazy-java.toml
- Deterministic TOML output via BTreeMap
- `--overwrite` flag to protect existing lazy-java.toml
- Full e2e tests with insta snapshots
- Unit tests for overwrite behavior

Closes #30