### PR TITLE
Revamp CLI output and add compile timing (Issue #61)

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -89,6 +89,10 @@ pub struct BuildArgs {
     #[arg(long = "build-all")]
     pub build_all: bool,
 
+    /// Show a per-step breakdown of compile times
+    #[arg(long = "timings")]
+    pub timings: bool,
+
     #[arg(long = "javac-args", num_args = 1.., allow_hyphen_values = true)]
     pub javac_args: Vec<String>,
 }

--- a/src/build/build_jar_tests.rs
+++ b/src/build/build_jar_tests.rs
@@ -10,7 +10,10 @@ fn test_ctx(target: &Path) -> Context {
         None,
         Some(
             ConfigTomlEdit::parse(&format!(
-                r#"[setup]
+                r#"[project]
+name = "test"
+
+[setup]
 src = "src"
 target = "{}"
 "#,

--- a/src/build/build_java.rs
+++ b/src/build/build_java.rs
@@ -1,7 +1,5 @@
-use std::process::ExitStatus;
-
 use colored::Colorize;
-use log::debug;
+use std::process::ExitStatus;
 
 use crate::Context;
 use crate::args::{BuildArgs, BuildCommand, BuildSubCommand, JarArgs};
@@ -16,8 +14,8 @@ use crate::lazy_java::LazyJava;
 
 use crate::build::BuildError;
 use crate::lsp::classpath::Classpath;
-use crate::utils::{GlobalContext, IOError};
 use crate::utils::find_main::find_java_files;
+use crate::utils::{GlobalContext, IOError, Timings};
 
 impl LazyJava {
     pub fn build(args: &BuildCommand, ctx: &Context) -> Result<(), BuildError> {
@@ -47,46 +45,43 @@ impl LazyJava {
             return Ok(());
         }
 
+        let mut timings = Timings::start();
         let build_data = BuildMetadata::fetch(&ctx.target);
-        if build_data.is_none() {
-            debug!("Could not find build data, full rebuild");
-            build_processors(args, ctx)?;
-
-            let status = Self::rebuild(args, ctx)?;
-            if !status.success() {
-                return Err(BuildError::MainCompilationErrors);
-            }
-            copy_resources(ctx)?;
-            save_metadata(ctx, status, None)?;
-
-            return Ok(());
-        }
-        let build_data = build_data.unwrap();
-        debug!("Found build data ");
 
         let current_lib_hash = hash_directory(&ctx.lib);
 
-        log::debug!(
-            "lib_hash: stored={}, current={}, match={}",
-            build_data.lib_hash,
-            current_lib_hash,
-            current_lib_hash == build_data.lib_hash
-        );
-        let lib_hash_match = current_lib_hash == build_data.lib_hash;
-        debug!("Lib Hash Match: {}", lib_hash_match);
+        let lib_hash_match = build_data
+            .as_ref()
+            .is_some_and(|t| current_lib_hash == t.lib_hash);
+        timings.record_current("Metadata parse");
 
         build_processors(args, ctx)?;
+        timings.record_current("Processor compile");
 
-        let status = if args.build_all || !lib_hash_match {
-            Self::rebuild(args, ctx)
+        let status = if args.build_all || !lib_hash_match || build_data.is_none() {
+            let r = Self::rebuild(args, ctx);
+            timings.record_current("Compile");
+            r
         } else {
-            Self::incrimental_build(args, ctx, &build_data)
+            Self::incrimental_build(args, ctx, build_data.as_ref().unwrap(), &mut timings)
         }?;
         copy_resources(ctx)?;
-        save_metadata(ctx, status, Some(build_data))?;
+        timings.record_current("Copy resources");
+
+        save_metadata(ctx, status, build_data)?;
 
         if !status.success() {
             return Err(BuildError::MainCompilationErrors);
+        }
+
+        if args.timings {
+            println!("{}", timings);
+        } else {
+            println!(
+                "{} {:.2}s",
+                "Compiled in".bold().green(),
+                timings.total.elapsed().as_secs_f64()
+            );
         }
         Ok(())
     }
@@ -94,8 +89,8 @@ impl LazyJava {
         args: &BuildArgs,
         ctx: &Context,
         build_data: &BuildMetadata,
+        timings: &mut Timings,
     ) -> Result<ExitStatus, BuildError> {
-        log::info!("Starting incremental build");
         let exclude = if let Some(s) = ctx.config.setup()
             && let Some(list) = s.exclude()
         {
@@ -105,7 +100,6 @@ impl LazyJava {
         };
 
         let graph = DependancyGraph::create(&ctx.src, &exclude)?;
-        log::debug!("Created dependency graph");
 
         let modified_files = find_modified_files(build_data, &ctx.src, &exclude)
             .map_err(|e| IOError::new("finding modified files", &ctx.src, e))?;
@@ -121,7 +115,6 @@ impl LazyJava {
             return Ok(ExitStatus::default());
         }
 
-        log::debug!("Found {} modified files", modified_files.len());
         let recompile = files_to_recompile(graph, modified_files)?;
 
         println!(
@@ -130,19 +123,18 @@ impl LazyJava {
             recompile.len(),
             if recompile.len() == 1 { "" } else { "s" }
         );
-        log::debug!("Need to recompile {} files", recompile.len());
+        timings.record_current("Incrimental processing");
 
         let status = compile_java(recompile, &ctx.bin, ctx, &args.javac_args, true)
             .map_err(|e| IOError::new("compiling java files", &ctx.bin, e))?;
 
-        log::debug!("Java compilation completed status {}", status);
+        timings.record_current("Incrimental compile");
 
         Ok(status)
     }
 
     fn rebuild(args: &BuildArgs, ctx: &Context) -> Result<ExitStatus, BuildError> {
         println!("{} using full rebuild", "Compiling".bold().green());
-        log::info!("Starting full rebuild");
         Classpath::generate(ctx)?;
         let exclude = if let Some(s) = ctx.config.setup()
             && let Some(list) = s.exclude()
@@ -161,7 +153,6 @@ impl LazyJava {
         Ok(status)
     }
     fn show_dependancy_graph(ctx: &Context) -> Result<(), BuildError> {
-        log::info!("Displaying dependency graph");
         let exclude = if let Some(s) = ctx.config.setup()
             && let Some(list) = s.exclude()
         {
@@ -171,8 +162,9 @@ impl LazyJava {
         };
         let graph = DependancyGraph::create(&ctx.src, &exclude)?;
 
+        println!("{}", "Dependancy graph".bold().green());
         for (_key, entry) in graph.nodes.iter() {
-            println!(" {}", entry.file_name,);
+            println!(" {}", entry.file_name.bold());
             for dep in &entry.dependancies {
                 println!("  - {}", dep);
             }
@@ -190,20 +182,23 @@ impl LazyJava {
         } else {
             Vec::new()
         };
-        log::info!("Displaying modified files");
         let stale_files = find_modified_files(&build_data, &ctx.src, &exclude)
             .map_err(|e| IOError::new("finding modified files", &ctx.src, e))?;
 
+        println!(
+            "{} {} file{} since last build",
+            "Modified".bold().green(),
+            stale_files.len(),
+            if stale_files.len() == 1 { "" } else { "s" }
+        );
         for file in stale_files {
-            println!("{}", file.to_string_lossy());
+            println!("  {}", file.to_string_lossy());
         }
 
         Ok(())
     }
     fn show_rebuild_files(ctx: &Context) -> Result<(), BuildError> {
         let build_data = BuildMetadata::fetch(&ctx.target).unwrap_or_default();
-
-        log::info!("Displaying files to rebuild");
 
         let exclude = if let Some(s) = ctx.config.setup()
             && let Some(list) = s.exclude()
@@ -219,14 +214,19 @@ impl LazyJava {
 
         let recompile = files_to_recompile(graph, stale_files)?;
 
+        println!(
+            "{} {} file{} to recompile",
+            "Stale".bold().green(),
+            recompile.len(),
+            if recompile.len() == 1 { "" } else { "s" }
+        );
         for file in recompile {
-            println!("{}", file.to_string_lossy());
+            println!("  {}", file.to_string_lossy());
         }
 
         Ok(())
     }
     fn show_depentants_graph(ctx: &Context) -> Result<(), BuildError> {
-        log::info!("Displaying dependants graph");
         let exclude = if let Some(s) = ctx.config.setup()
             && let Some(list) = s.exclude()
         {
@@ -235,8 +235,9 @@ impl LazyJava {
             Vec::new()
         };
         let graph = DependancyGraph::create(&ctx.src, &exclude)?;
+        println!("{}", "Dependants graph".bold().green());
         for (_key, entry) in graph.nodes.iter() {
-            println!(" {}", entry.file_name,);
+            println!(" {}", entry.file_name.bold());
             for dep in &entry.dependants {
                 println!("  - {}", dep);
             }

--- a/src/build/metadata.rs
+++ b/src/build/metadata.rs
@@ -34,19 +34,13 @@ impl BuildMetadata {
         }
     }
     pub fn fetch(target: &Path) -> Option<BuildMetadata> {
-        let build_str = fs::read_to_string(target.join(BUILD_METADATA_NAME));
-        if build_str.is_err() {
+        let Ok(build_str) = fs::read_to_string(target.join(BUILD_METADATA_NAME)) else {
             return None;
-        }
-        let build_str = build_str.unwrap();
-
-        let metadata: Result<BuildMetadata, toml::de::Error> = toml::from_str(&build_str);
-
-        if metadata.is_err() {
+        };
+        let Ok(metadata) = toml::from_str(&build_str) else {
             return None;
-        }
-
-        Some(metadata.unwrap())
+        };
+        Some(metadata)
     }
     pub fn write(&self, target: &Path) -> Result<(), BuildError> {
         let path = target.join(BUILD_METADATA_NAME);

--- a/src/build/processors/build.rs
+++ b/src/build/processors/build.rs
@@ -23,10 +23,6 @@ pub fn build_processors(build_args: &BuildArgs, ctx: &Context) -> Result<(), Bui
 
     let full_paths: Vec<PathBuf> = processors.values().map(|p| p.path.clone()).collect();
 
-    if full_paths.is_empty() {
-        return Ok(());
-    }
-
     log::debug!("Processor source paths: {:?}", full_paths);
 
     let _ = fs::remove_dir_all(ctx.bin_processors.join("META-INF"));

--- a/src/build/resources.rs
+++ b/src/build/resources.rs
@@ -5,7 +5,11 @@ use std::{
 
 use globset::{Glob, GlobSet, GlobSetBuilder};
 
-use crate::{Context, build::BuildError, utils::{IOError, fs}};
+use crate::{
+    Context,
+    build::BuildError,
+    utils::{IOError, fs},
+};
 
 pub fn copy_resources(ctx: &Context) -> Result<(), BuildError> {
     let glob_set = build_globset(ctx);
@@ -23,9 +27,10 @@ fn remove_unknown_resources(
 ) -> Result<isize, BuildError> {
     let mut change = 0;
     for dir in fs::read_dir(current)
-        .map_err(|s| IOError::new("reading build directory", current, s))?.flatten()
+        .map_err(|s| IOError::new("reading build directory", current, s))?
+        .flatten()
     {
-        if dir.file_type().unwrap().is_dir() {
+        if dir.file_type().is_ok_and(|t| t.is_dir()) {
             change += remove_unknown_resources(resources, &dir.path(), ctx)?;
         } else {
             if let Some(ext) = dir.path().extension() {
@@ -75,7 +80,10 @@ fn add_resources(
     ctx: &Context,
 ) -> Result<HashSet<PathBuf>, BuildError> {
     let mut resources = HashSet::new();
-    for dir in fs::read_dir(path).map_err(|e| IOError::new("reading source directory", path, e))?.flatten() {
+    for dir in fs::read_dir(path)
+        .map_err(|e| IOError::new("reading source directory", path, e))?
+        .flatten()
+    {
         if is_excluded(&dir, glob_set) {
             continue;
         }

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -12,7 +12,7 @@ use crate::{Context, lazy_java_error::LazyJavaError, lsp::classpath::Classpath};
 pub fn sync_lsp_config(ctx: &Context) -> Result<(), LazyJavaError> {
     Classpath::generate_if_stale(ctx)?;
     DotSettings::generate(&ctx.root)?;
-    DotProject::generate(&ctx.root, &ctx.config)?;
+    DotProject::generate(ctx)?;
 
     Ok(())
 }

--- a/src/lsp/project.rs
+++ b/src/lsp/project.rs
@@ -1,14 +1,12 @@
-use std::{io, path::Path};
-
-use crate::{config::ConfigTomlEdit, utils::fs};
+use crate::{Context, lazy_java_error::LazyJavaError, utils::fs};
 
 pub struct DotProject {}
 
 impl DotProject {
-    pub fn generate(root: &Path, config: &ConfigTomlEdit) -> Result<(), io::Error> {
-        let name: &str = &config.project().unwrap().name().unwrap();
+    pub fn generate(ctx: &Context) -> Result<(), LazyJavaError> {
+        let name = ctx.name();
         fs::write(
-            root.join(".project"),
+            ctx.root.join(".project"),
             format!(
                 r#"<?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
@@ -40,6 +38,7 @@ impl DotProject {
 </projectDescription>
 "#
             ),
-        )
+        )?;
+        Ok(())
     }
 }

--- a/src/run/run_java.rs
+++ b/src/run/run_java.rs
@@ -45,7 +45,6 @@ impl LazyJava {
         }
 
         println!("{} {}", "Running".bold().green(), jar_path.display());
-        log::info!("Running jar: {:?}", jar_path);
 
         if GlobalContext::is_dry_run() {
             return Ok(());

--- a/src/utils/context/context.rs
+++ b/src/utils/context/context.rs
@@ -70,6 +70,8 @@ impl Context {
             None => ConfigTomlEdit::fetch(&root),
         }?;
 
+        Self::assert_project_name(&config)?;
+
         log::info!("Project root: {:?}", root);
 
         let relative_target = Self::target_path(args, &config).to_string();
@@ -115,6 +117,20 @@ impl Context {
         };
 
         Ok(ctx)
+    }
+
+    fn assert_project_name(config: &ConfigTomlEdit) -> Result<(), ContextError> {
+        if config.project().and_then(|p| p.name()).is_none() {
+            return Err(ContextError::MissingProjectName);
+        }
+        Ok(())
+    }
+
+    pub fn name(&self) -> String {
+        self.config
+            .project()
+            .and_then(|p| p.name())
+            .expect("project name is asserted during context construction")
     }
 
     pub fn assert_src_exists(&self) -> Result<(), ContextError> {

--- a/src/utils/context/context_error.rs
+++ b/src/utils/context/context_error.rs
@@ -21,6 +21,9 @@ pub enum ContextError {
     #[error(r#"Could not find source directory {0}, try changing the source location, or add the directory"#)]
     NoSource(String),
 
+    #[error("lazy-java.toml is missing the project name")]
+    MissingProjectName,
+
     #[error("Error when operating on config file")]
     ConfigError(#[from] ConfigError),
 
@@ -44,6 +47,9 @@ impl DiagnosticProvider for ContextError {
             ContextError::NoSource(path) => Diagnostic::new("Source directory not found")
                 .message(format!("Could not find source directory {path}."))
                 .help("Change the source location, or add the directory."),
+            ContextError::MissingProjectName => Diagnostic::new("Missing project name")
+                .message("The [project] section of lazy-java.toml must define a name.")
+                .help("Add a name to the [project] section of lazy-java.toml."),
             ContextError::ConfigError(err) => err.diagnostic(),
             ContextError::LockFileError(err) => err.diagnostic(),
             ContextError::IoError(err) => err.diagnostic(),

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -6,6 +6,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use colored::Colorize;
+
 use crate::utils::GlobalContext;
 
 pub use std_fs::{DirEntry, Metadata, ReadDir};
@@ -13,7 +15,7 @@ pub use std_fs::{DirEntry, Metadata, ReadDir};
 pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result<()> {
     let path = path.as_ref();
     if GlobalContext::is_dry_run() {
-        println!("dry-run: would write {}", path.display());
+        println!("{}: would write {}", "dry-run".red().bold(), path.display());
         return Ok(());
     }
     std_fs::write(path, contents)
@@ -22,7 +24,11 @@ pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result
 pub fn create_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
     let path = path.as_ref();
     if GlobalContext::is_dry_run() {
-        println!("dry-run: would create directory {}", path.display());
+        println!(
+            "{}: would create directory {}",
+            "dry-run".red().bold(),
+            path.display()
+        );
         return Ok(());
     }
     std_fs::create_dir(path)
@@ -31,7 +37,11 @@ pub fn create_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
 pub fn create_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
     let path = path.as_ref();
     if GlobalContext::is_dry_run() {
-        println!("dry-run: would create directory {}", path.display());
+        println!(
+            "{}: would create directory {}",
+            "dry-run".red().bold(),
+            path.display()
+        );
         return Ok(());
     }
     std_fs::create_dir_all(path)
@@ -40,7 +50,7 @@ pub fn create_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
 pub fn remove_file<P: AsRef<Path>>(path: P) -> io::Result<()> {
     let path = path.as_ref();
     if GlobalContext::is_dry_run() {
-        println!("dry-run: would remove file {}", path.display());
+        println!("{}: would remove file {}", "dry-run".red().bold(), path.display());
         return Ok(());
     }
     std_fs::remove_file(path)
@@ -49,7 +59,11 @@ pub fn remove_file<P: AsRef<Path>>(path: P) -> io::Result<()> {
 pub fn remove_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
     let path = path.as_ref();
     if GlobalContext::is_dry_run() {
-        println!("dry-run: would remove directory {}", path.display());
+        println!(
+            "{}: would remove directory {}",
+            "dry-run".red().bold(),
+            path.display()
+        );
         return Ok(());
     }
     std_fs::remove_dir_all(path)
@@ -59,7 +73,12 @@ pub fn copy<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<u64> {
     let from = from.as_ref();
     let to = to.as_ref();
     if GlobalContext::is_dry_run() {
-        println!("dry-run: would copy {} to {}", from.display(), to.display());
+        println!(
+            "{}: would copy {} to {}",
+            "dry-run".red().bold(),
+            from.display(),
+            to.display()
+        );
         return Ok(0);
     }
     std_fs::copy(from, to)

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,8 +3,10 @@ pub mod find_root;
 pub mod fs;
 mod join_dir;
 pub mod processes;
+pub mod timings;
 
 pub use join_dir::join_directory;
+pub use timings::Timings;
 
 mod context;
 mod errors;

--- a/src/utils/timings.rs
+++ b/src/utils/timings.rs
@@ -1,0 +1,49 @@
+use std::{
+    fmt::Display,
+    time::{Duration, Instant},
+};
+
+use colored::Colorize;
+
+pub struct Timings {
+    pub total: Instant,
+    current: Instant,
+    steps: Vec<(String, Duration)>,
+}
+
+impl Timings {
+    pub fn start() -> Self {
+        Timings {
+            total: Instant::now(),
+            current: Instant::now(),
+            steps: Vec::new(),
+        }
+    }
+
+    pub fn record(&mut self, name: impl Into<String>, duration: Duration) {
+        self.steps.push((name.into(), duration));
+    }
+
+    pub fn record_current(&mut self, name: impl Into<String>) {
+        self.steps.push((name.into(), self.current.elapsed()));
+        self.current = Instant::now();
+    }
+}
+impl Display for Timings {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (desc, time) in &self.steps {
+            writeln!(
+                f,
+                "  {:<36} {:>10.4}s",
+                desc.white().bold(),
+                time.as_secs_f64()
+            )?;
+        }
+        writeln!(
+            f,
+            "  {:<36} {:>10.4}s",
+            "Total time".green().bold(),
+            self.total.elapsed().as_secs_f64()
+        )
+    }
+}

--- a/test_filesystem/test10/target/.lazy-java-build
+++ b/test_filesystem/test10/target/.lazy-java-build
@@ -4,5 +4,5 @@ bin_hash = 13914183444989212301
 build_passed = true
 
 [time_stamp]
-secs_since_epoch = 1785690006
-nanos_since_epoch = 576146000
+secs_since_epoch = 1785710290
+nanos_since_epoch = 430987000


### PR DESCRIPTION
Closes #61

## Summary

Implements the remaining #61 work on top of the error-handling overhaul (#66).

### Compile timing
- Adds a `--timings` flag to `build` that prints a per-step breakdown (metadata parse, processor compile, compile, resource copy) plus total time
- Plain builds always print total wall-clock time (`Compiled in X.XXs`)

### Output revamp
- `build modified` / `build stale` now print `Modified N file(s) since last build` / `Stale N file(s) to recompile` with indented file lists
- `build dependancies` / `build dependants` get bold headers and consistent indented entries
- Dry-run messages in `utils/fs.rs` print a red bold `dry-run:` prefix consistent across all commands
- Removed duplicate `log::info!` lines that mirrored terminal output

### Context & LSP
- `Context` construction asserts a project name exists; new `MissingProjectName` config error with a diagnostic + help
- `Context::name()` helper replaces the ad-hoc unwraps in `lsp/project.rs`; `DotProject::generate` takes `ctx` and returns proper errors

### Legacy cleanup
- `metadata.rs` `fetch` rewritten with `let-else` (no unwraps)
- `resources.rs` uses `is_ok_and` instead of an unwrap on `file_type()`
- `processors/build.rs` drops a redundant `is_empty` check that could never trigger

## Verification
- `cargo test`: 63 lib + 19 e2e tests pass
- No new clippy warnings in touched files