### PR TITLE
Multi-JDK version config, Maven scopes, external resources, and import-pom improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,6 +1207,7 @@ dependencies = [
  "quick-xml",
  "regex",
  "reqwest",
+ "same-file",
  "serde",
  "strum",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ globset = "0.4.18"
 walkdir = "2.5.0"
 zip = "8.6.0"
 toml-edit-derive = { path = "toml-edit-derive/core" }
+same-file = "1.0.6"
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/src/args.rs
+++ b/src/args.rs
@@ -169,6 +169,9 @@ pub struct AddArgs {
     pub artifact: String,
     // the specific version to add
     pub artifact_version: Option<String>,
+
+    // the scope of the dependancy
+    pub scope: Option<String>,
 }
 
 #[derive(Debug, Parser, Clone)]
@@ -215,6 +218,10 @@ pub struct ImportPomArgs {
     /// Overwrite existing lazy-java.toml if it exists
     #[arg(long = "overwrite")]
     pub overwrite: bool,
+
+    /// Will only import the pom.xml dependencies and not other configurations
+    #[arg(long = "only-dependencies")]
+    pub only_dependencies: bool,
 }
 
 #[derive(Debug, Parser, Clone)]

--- a/src/args.rs
+++ b/src/args.rs
@@ -99,6 +99,10 @@ pub struct BuildArgs {
 
     #[arg(long = "javac-args", num_args = 1.., allow_hyphen_values = true)]
     pub javac_args: Vec<String>,
+
+    /// JDK release version passed to javac via --release (e.g. 17)
+    #[arg(long = "release")]
+    pub release: Option<String>,
 }
 
 #[derive(Parser, Debug, Clone)]

--- a/src/build/build_error.rs
+++ b/src/build/build_error.rs
@@ -33,6 +33,15 @@ pub enum BuildError {
         "No main class specified, provide one in the command line or insert into the lazy-java.toml file"
     )]
     NoMainClass,
+
+    #[error("`javac` was not found on the PATH, ensure a JDK is installed and on the PATH")]
+    JavacNotFound,
+
+    #[error("`jar` was not found on the PATH, ensure a JDK is installed and on the PATH")]
+    JarNotFound,
+
+    #[error("`java` was not found on the PATH, ensure a JDK is installed and on the PATH")]
+    JavaNotFound,
 }
 
 impl DiagnosticProvider for BuildError {
@@ -58,6 +67,15 @@ impl DiagnosticProvider for BuildError {
             BuildError::NoMainClass => Diagnostic::new("No main class specified")
                 .message("No main class was specified for the jar.")
                 .help("Provide one in the command line or insert into the lazy-java.toml file."),
+            BuildError::JavacNotFound => Diagnostic::new("javac not found")
+                .message("The `javac` compiler could not be found on the PATH.")
+                .help("Ensure a JDK is installed and its bin directory is on the PATH."),
+            BuildError::JarNotFound => Diagnostic::new("jar not found")
+                .message("The `jar` tool could not be found on the PATH.")
+                .help("Ensure a JDK is installed and its bin directory is on the PATH."),
+            BuildError::JavaNotFound => Diagnostic::new("java not found")
+                .message("The `java` command could not be found on the PATH.")
+                .help("Ensure a JDK is installed and its bin directory is on the PATH."),
         }
     }
 }

--- a/src/build/build_jar.rs
+++ b/src/build/build_jar.rs
@@ -2,13 +2,13 @@ use colored::Colorize;
 use std::{
     io,
     path::{Path, absolute},
-    process::{Command, Stdio},
+    process::Stdio,
 };
 use walkdir::WalkDir;
 
 use log::debug;
 
-use crate::{Context, args::JarArgs, build::BuildError, utils::{IOError, fs, GlobalContext}};
+use crate::{Context, args::JarArgs, build::BuildError, utils::{GlobalContext, IOError, fs, processes::java_tool_command}};
 
 pub fn build_jar(args: &JarArgs, ctx: &Context) -> Result<(), BuildError> {
     // ISSUE: cheap dry run this is not good and should be improved
@@ -119,14 +119,20 @@ fn build_fat_jar_inner(
 fn extract_jar(jar: &Path, dest: &Path) -> Result<(), BuildError> {
     let jar = absolute(jar).map_err(|e| IOError::new("resolving jar path", jar, e))?;
 
-    let status = Command::new("jar")
+    let status = java_tool_command("jar")
         .current_dir(dest)
         .arg("xf")
         .arg(&jar)
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
         .status()
-        .map_err(|e| IOError::new("extracting jar", &jar, e))?;
+        .map_err(|e| {
+            if e.kind() == io::ErrorKind::NotFound {
+                BuildError::JarNotFound
+            } else {
+                BuildError::IoError(IOError::new("extracting jar", &jar, e))
+            }
+        })?;
     if !status.success() {
         return Err(BuildError::JarCreationError);
     }
@@ -221,7 +227,7 @@ pub(crate) fn build_manifest(entry_point: &str, ctx: &Context) -> Result<String,
 }
 
 fn run_jar_command(output: &Path, manifest: &Path, dirs: &[&Path]) -> Result<(), BuildError> {
-    let mut cmd = Command::new("jar");
+    let mut cmd = java_tool_command("jar");
     cmd.arg("-cfm").arg(output).arg(manifest);
     for dir in dirs {
         cmd.arg("-C").arg(dir).arg(".");
@@ -231,7 +237,13 @@ fn run_jar_command(output: &Path, manifest: &Path, dirs: &[&Path]) -> Result<(),
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
         .status()
-        .map_err(|e| IOError::new("running jar command", output, e))?;
+        .map_err(|e| {
+            if e.kind() == io::ErrorKind::NotFound {
+                BuildError::JarNotFound
+            } else {
+                BuildError::IoError(IOError::new("running jar command", output, e))
+            }
+        })?;
     if !status.success() {
         return Err(BuildError::JarCreationError);
     }

--- a/src/build/build_java.rs
+++ b/src/build/build_java.rs
@@ -16,6 +16,7 @@ use crate::lazy_java::LazyJava;
 use crate::build::BuildError;
 use crate::lsp::classpath::Classpath;
 use crate::utils::find_main::find_java_files_glob;
+use crate::utils::jdk_version::desired_jdk_version;
 use crate::utils::{GlobalContext, IOError, Timings};
 
 impl LazyJava {
@@ -53,6 +54,11 @@ impl LazyJava {
         let lib_hash_match = build_data
             .as_ref()
             .is_some_and(|t| current_lib_hash == t.lib_hash);
+
+        let jdk = desired_jdk_version(Some(args), Some(ctx));
+        let version_match = build_data
+            .as_ref()
+            .is_some_and(|t| t.java_version == jdk);
         timings.record_current("Metadata parse");
 
         build_processors(args, ctx)?;
@@ -61,7 +67,7 @@ impl LazyJava {
         let glob = build_globset(ctx);
 
         let files: Result<Vec<PathBuf>, BuildError> =
-            if args.build_all || !lib_hash_match || build_data.is_none() {
+            if args.build_all || !lib_hash_match || build_data.is_none() || !version_match {
                 let files = find_java_files_glob(&ctx.src, &glob);
                 println!(
                     "{} using full build ({} file{})",
@@ -94,8 +100,8 @@ impl LazyJava {
         timings.record_current("Incrimental prcoessing");
         let mut status: Option<ExitStatus> = None;
         if !files.is_empty() {
-            let e_status = compile_java(files, &ctx.bin, ctx, &args.javac_args, true)
-                .map_err(|e| IOError::new("compiling java files", &ctx.bin, e))?;
+            let e_status = compile_java(files, &ctx.bin, ctx, &args.javac_args, true, Some(&jdk))?;
+
             timings.record_current("Compile");
             status = Some(e_status);
         }
@@ -104,7 +110,7 @@ impl LazyJava {
         timings.record_current("Copy resources");
 
         if let Some(status) = status {
-            save_metadata(ctx, status, build_data)?;
+            save_metadata(ctx, status, build_data, &jdk)?;
 
             if !status.success() {
                 return Err(BuildError::MainCompilationErrors);

--- a/src/build/build_java.rs
+++ b/src/build/build_java.rs
@@ -8,7 +8,7 @@ use crate::args::{BuildArgs, BuildCommand, BuildSubCommand, JarArgs};
 use crate::build::build_jar::build_jar;
 use crate::build::compile::compile_java;
 use crate::build::graph::Graph;
-use crate::build::metadata::{BuildMetadata, hash_directory, save_metadata};
+use crate::build::metadata::{BuildMetadata, required_full_build, save_metadata};
 use crate::build::processors::build_processors;
 use crate::build::resources::copy_resources;
 use crate::lazy_java::LazyJava;
@@ -49,16 +49,6 @@ impl LazyJava {
         let mut timings = Timings::start("Build");
         let build_data = BuildMetadata::fetch(&ctx.target);
 
-        let current_lib_hash = hash_directory(&ctx.lib);
-
-        let lib_hash_match = build_data
-            .as_ref()
-            .is_some_and(|t| current_lib_hash == t.lib_hash);
-
-        let jdk = desired_jdk_version(Some(args), Some(ctx));
-        let version_match = build_data
-            .as_ref()
-            .is_some_and(|t| t.java_version == jdk);
         timings.record_current("Metadata parse");
 
         build_processors(args, ctx)?;
@@ -67,7 +57,7 @@ impl LazyJava {
         let glob = build_globset(ctx);
 
         let files: Result<Vec<PathBuf>, BuildError> =
-            if args.build_all || !lib_hash_match || build_data.is_none() || !version_match {
+            if required_full_build(args, ctx, build_data.as_ref()) {
                 let files = find_java_files_glob(&ctx.src, &glob);
                 println!(
                     "{} using full build ({} file{})",
@@ -98,6 +88,8 @@ impl LazyJava {
         }
 
         timings.record_current("Incrimental prcoessing");
+        let jdk = desired_jdk_version(Some(args), Some(ctx));
+
         let mut status: Option<ExitStatus> = None;
         if !files.is_empty() {
             let e_status = compile_java(files, &ctx.bin, ctx, &args.javac_args, true, Some(&jdk))?;

--- a/src/build/compile.rs
+++ b/src/build/compile.rs
@@ -1,12 +1,16 @@
 use std::{
     io,
     path::{self, Path, PathBuf},
-    process::{Command, ExitStatus, Output, Stdio},
+    process::{ExitStatus, Output, Stdio},
 };
 
 use log::warn;
 
-use crate::{Context, JAVAC_SEPERATOR, utils::join_directory};
+use crate::{
+    Context, JAVAC_SEPERATOR,
+    build::BuildError,
+    utils::{IOError, join_directory, processes::java_tool_command},
+};
 
 /// Anything postfixed with list should be a : or ; seperated list depending on platform, expect
 /// src_list that is a space seperated list
@@ -20,13 +24,14 @@ pub(crate) fn compile_command(
     src_generated_dir: &str,
     build_processor_dir: &str,
     javac_args: &Vec<String>,
+    release: Option<&str>,
 ) -> Result<Output, io::Error> {
     let sep = JAVAC_SEPERATOR;
     let classpath =
         format!("{build_processor_dir}{sep}{bin_dir}{sep}{annotation_lib}/*{sep}{lib_dir}/*");
     let processorpath = format!("{annotation_lib_list}{sep}{build_processor_dir}");
 
-    let mut cmd = Command::new("javac");
+    let mut cmd = java_tool_command("javac");
     cmd.arg("-s")
         .arg(src_generated_dir)
         .arg("-processorpath")
@@ -35,6 +40,9 @@ pub(crate) fn compile_command(
         .arg(&classpath)
         .arg("-d")
         .arg(output_dir);
+    if let Some(version) = release {
+        cmd.arg("--release").arg(version);
+    }
     cmd.args(javac_args);
     for src in src_list.split_whitespace() {
         cmd.arg(src);
@@ -54,7 +62,8 @@ pub fn compile_java(
     ctx: &Context,
     javac_args: &Vec<String>,
     compile_generated_source: bool,
-) -> Result<ExitStatus, io::Error> {
+    release: Option<&str>,
+) -> Result<ExitStatus, BuildError> {
     log::debug!("Using library path: {:?}", ctx.lib);
     log::debug!("Javac arguments: {:?}", javac_args);
 
@@ -70,14 +79,21 @@ pub fn compile_java(
         .map(|c_path| c_path.to_string_lossy().to_string())
         .collect();
 
-    let ab_dest = path::absolute(dest)?;
-    let ab_lib = path::absolute(&ctx.lib)?;
-    let ab_bin = path::absolute(&ctx.bin)?;
-    let ab_annotation_lib = path::absolute(&ctx.lib_annotations)?;
+    let resolve = |what: &'static str, p: &Path| -> Result<PathBuf, BuildError> {
+        path::absolute(p).map_err(|e| BuildError::IoError(IOError::new(what, p, e)))
+    };
+
+    let ab_dest = resolve("resolving output directory", dest)?;
+    let ab_lib = resolve("resolving library directory", &ctx.lib)?;
+    let ab_bin = resolve("resolving bin directory", &ctx.bin)?;
+    let ab_annotation_lib = resolve(
+        "resolving annotation library directory",
+        &ctx.lib_annotations,
+    )?;
     let ab_annotation_lib_list = join_directory(&ctx.lib_annotations, JAVAC_SEPERATOR);
-    let ab_src_generated = path::absolute(&ctx.src_generated)?;
+    let ab_src_generated = resolve("resolving generated source directory", &ctx.src_generated)?;
     let src_generated_destructured = join_directory(&ab_src_generated, ' ');
-    let ab_bin_processor = path::absolute(&ctx.bin_processors)?;
+    let ab_bin_processor = resolve("resolving processor bin directory", &ctx.bin_processors)?;
     log::debug!("Processor build output directory: {:?}", ab_bin_processor);
     log::debug!("Annotation library path: {:?}", ab_annotation_lib_list);
 
@@ -87,7 +103,7 @@ pub fn compile_java(
         src_des.push_str(&src_generated_destructured);
     }
 
-    let command = compile_command(
+    let output = match compile_command(
         &src_des,
         ab_dest.to_str().unwrap(),
         ab_bin.to_str().unwrap(),
@@ -97,9 +113,18 @@ pub fn compile_java(
         ab_src_generated.to_str().unwrap(),
         ab_bin_processor.to_str().unwrap(),
         javac_args,
-    );
-
-    let output = command.expect("Compile Command Failed");
+        release,
+    ) {
+        Ok(output) => output,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Err(BuildError::JavacNotFound),
+        Err(e) => {
+            return Err(BuildError::IoError(IOError::new(
+                "running javac",
+                &ab_bin,
+                e,
+            )));
+        }
+    };
 
     if output.status.success() {
         log::info!("Compilation completed successfully");

--- a/src/build/compile_tests.rs
+++ b/src/build/compile_tests.rs
@@ -46,6 +46,7 @@ fn test_compile_command_simple() -> Result<(), std::io::Error> {
         &src_generated_dir.to_string_lossy(),
         &processor_dir.to_string_lossy(),
         &Vec::new(),
+        None,
     )?;
 
     assert!(
@@ -100,6 +101,7 @@ public class Greeting {{
         &src_generated_dir.to_string_lossy(),
         &processor_dir.to_string_lossy(),
         &Vec::new(),
+        None,
     )?;
 
     assert!(

--- a/src/build/metadata.rs
+++ b/src/build/metadata.rs
@@ -1,23 +1,26 @@
 use std::{
     hash::{DefaultHasher, Hash, Hasher},
-    path::Path,
+    path::{Path, PathBuf},
     process::ExitStatus,
     time::SystemTime,
 };
 
+use same_file::is_same_file;
 use serde::{Deserialize, Serialize};
 use walkdir::DirEntry;
 
 use crate::{
     BUILD_METADATA_NAME, Context,
+    args::BuildArgs,
     build::BuildError,
-    utils::{IOError, TomlSerializeError, fs},
+    utils::{IOError, TomlSerializeError, fs, jdk_version::desired_jdk_version},
 };
 
 #[derive(Clone, Serialize, Deserialize, Eq, PartialEq, PartialOrd, Ord)]
 pub struct BuildMetadata {
     pub time_stamp: SystemTime,
     pub java_version: String,
+    pub src: PathBuf,
     pub lib_hash: u64,
     pub bin_hash: u64,
     pub build_passed: bool,
@@ -28,6 +31,7 @@ impl BuildMetadata {
         BuildMetadata {
             time_stamp: SystemTime::now(),
             java_version: "".into(),
+            src: "".into(),
             lib_hash: 0,
             bin_hash: 0,
             build_passed: false,
@@ -57,6 +61,21 @@ impl Default for BuildMetadata {
         Self::new()
     }
 }
+pub fn required_full_build(args: &BuildArgs, ctx: &Context, meta: Option<&BuildMetadata>) -> bool {
+    let Some(meta) = meta else {
+        return true;
+    };
+
+    let current_lib_hash = hash_directory(&ctx.lib);
+    let lib_hash_match = current_lib_hash == meta.lib_hash;
+
+    let jdk = desired_jdk_version(Some(args), Some(ctx));
+    let version_match = meta.java_version == jdk;
+
+    let src_match = is_same_file(&meta.src, &ctx.src).unwrap_or(false);
+
+    args.build_all || !lib_hash_match || !version_match || !src_match
+}
 
 pub fn save_metadata(
     ctx: &Context,
@@ -78,6 +97,7 @@ pub fn save_metadata(
         lib_hash: hash_directory(&ctx.lib),
         bin_hash: hash_directory(&ctx.bin),
         build_passed: status.success(),
+        src: ctx.src.clone(),
     };
 
     meta.write(&ctx.target)?;

--- a/src/build/metadata.rs
+++ b/src/build/metadata.rs
@@ -62,6 +62,7 @@ pub fn save_metadata(
     ctx: &Context,
     status: ExitStatus,
     meta: Option<BuildMetadata>,
+    jdk: &str,
 ) -> Result<(), BuildError> {
     let time = if !status.success() {
         match meta {
@@ -73,7 +74,7 @@ pub fn save_metadata(
     };
     let meta = BuildMetadata {
         time_stamp: time,
-        java_version: "25".to_string(),
+        java_version: jdk.to_string(),
         lib_hash: hash_directory(&ctx.lib),
         bin_hash: hash_directory(&ctx.bin),
         build_passed: status.success(),

--- a/src/build/metadata_tests.rs
+++ b/src/build/metadata_tests.rs
@@ -27,6 +27,7 @@ mod tests {
         let meta = BuildMetadata {
             time_stamp: SystemTime::UNIX_EPOCH,
             java_version: "21".into(),
+            src: "src".into(),
             lib_hash: 42,
             bin_hash: 123,
             build_passed: true,

--- a/src/build/processors/build.rs
+++ b/src/build/processors/build.rs
@@ -32,14 +32,15 @@ pub fn build_processors(build_args: &BuildArgs, ctx: &Context) -> Result<(), Bui
         processors.len(),
         ctx.bin_processors
     );
+    let release = crate::utils::jdk_version::desired_jdk_version(Some(build_args), Some(ctx));
     let result = compile_java(
         full_paths,
         &ctx.bin_processors,
         ctx,
         &build_args.javac_args,
         false,
-    )
-    .map_err(|e| IOError::new("compiling annotation processors", &ctx.bin_processors, e))?;
+        Some(&release),
+    )?;
     log::info!(
         "Annotation processor compilation completed with status: {}",
         result

--- a/src/build/resources.rs
+++ b/src/build/resources.rs
@@ -3,22 +3,76 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use globset::{Glob, GlobSet, GlobSetBuilder};
-
 use crate::{
     Context,
     build::BuildError,
     utils::{IOError, fs},
 };
+use globset::{Glob, GlobSet, GlobSetBuilder};
+use same_file::is_same_file;
 
 pub fn copy_resources(ctx: &Context) -> Result<(), BuildError> {
-    let glob_set = build_globset(ctx);
-    let resource_paths = add_resources(&ctx.src, Path::new(""), &glob_set, ctx)?;
+    let list = if let Some(r) = ctx.config.resources()
+        && let Some(l) = r.exclude()
+    {
+        l
+    } else {
+        Vec::new()
+    };
+    let glob_set = build_globset(&list);
+
+    let mut resource_paths = add_resources(&ctx.src, Path::new(""), &glob_set, ctx)?;
     log::info!("Found {} resources", resource_paths.len());
+
+    let external = if let Some(r) = ctx.config.resources()
+        && let Some(list) = r.external()
+    {
+        list
+    } else {
+        Vec::new()
+    };
+    let glob_external = build_globset(&external);
+
+    let external_paths = add_external_resources(&ctx.root, &glob_external, ctx)?;
+
+    resource_paths.extend(external_paths);
 
     let removed = remove_unknown_resources(&resource_paths, &ctx.bin, ctx)?;
     log::info!("Removed {} resources", removed);
     Ok(())
+}
+fn add_external_resources(
+    path: &Path,
+    glob_set: &GlobSet,
+    ctx: &Context,
+) -> Result<HashSet<PathBuf>, BuildError> {
+    let mut res = HashSet::new();
+    for entry in fs::read_dir(path)
+        .map_err(|s| IOError::new("reading project directory", path, s))?
+        .flatten()
+    {
+        let p = entry.path();
+
+        if is_same_file(&p, &ctx.src).unwrap_or(false)
+            || is_same_file(&p, &ctx.target).unwrap_or(false)
+            || is_same_file(&p, &ctx.bin).unwrap_or(false)
+        {
+            continue;
+        }
+        if entry.file_type().is_ok_and(|t| t.is_dir()) {
+            if entry.file_name().to_string_lossy().starts_with('.') {
+                continue;
+            }
+            res.extend(add_external_resources(&p, glob_set, ctx)?);
+        } else {
+            let relative = p.strip_prefix(&ctx.root).unwrap_or(&p);
+            if glob_set.is_match(relative) {
+                res.insert(copy_file(&entry, Path::new("."), ctx)?);
+            }
+        }
+    }
+
+    Ok(res)
 }
 fn remove_unknown_resources(
     resources: &HashSet<PathBuf>,
@@ -56,17 +110,13 @@ fn remove_file(resources: &HashSet<PathBuf>, dir: &fs::DirEntry) -> Result<isize
 
     Ok(0)
 }
-fn build_globset(ctx: &Context) -> GlobSet {
+fn build_globset(list: &[String]) -> GlobSet {
     let mut builder = GlobSetBuilder::new();
-    if let Some(r) = ctx.config.resources()
-        && let Some(exclude) = r.exclude()
-    {
-        for rule in exclude {
-            if let Ok(glob_rule) = Glob::new(&rule) {
-                builder.add(glob_rule);
-            } else {
-                log::warn!("Invalid glob rule, \"{}\" is not a valid rule", rule);
-            }
+    for rule in list {
+        if let Ok(glob_rule) = Glob::new(rule) {
+            builder.add(glob_rule);
+        } else {
+            log::warn!("Invalid glob rule, \"{}\" is not a valid rule", rule);
         }
     }
 

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, io::ErrorKind, path::Path};
+use std::{collections::HashMap, io::ErrorKind, path::Path, str::FromStr};
 
 use colored::Colorize;
 use log::debug;
@@ -8,7 +8,9 @@ use crate::{
     args::{AddArgs, RemoveArgs},
     config::{ConfigDependancy, ConfigTomlEdit, config_error::ConfigError},
     lock_file::LockFile,
-    maven_central::{MavenError, MavenIdBuf, PartialMavenIdBuf, fetch_artifact_metadata},
+    maven_central::{
+        MavenError, MavenIdBuf, PartialMavenIdBuf, fetch_artifact_metadata, pom::Scope,
+    },
     utils::{IOError, fs},
 };
 impl ConfigTomlEdit {
@@ -63,7 +65,14 @@ impl ConfigTomlEdit {
         value.version_mut().replace(id.version.clone());
         value.group_mut().replace(id.group.clone());
 
-        lockfile.add_package(id)?;
+        let scope = Scope::from_str(add_args.scope.as_ref().map_or("", |s| s.as_str())).ok();
+        if let Some(s) = &add_args.scope
+            && scope.is_none()
+        {
+            println!("{}: unknown scope `{}`", "Warning".yellow().bold(), s)
+        }
+
+        lockfile.add_package(id, scope)?;
 
         self.sync_lock_file(&mut lockfile, ctx)?;
 
@@ -83,8 +92,8 @@ impl ConfigTomlEdit {
         let mut version: Option<String> = None;
         if let Some(deps) = self.dependancies()
             && let Some(d) = deps.get(&partial_id.artifact)
-                && d.group().as_ref() == Some(&partial_id.group)
-                && let Some(v) = d.version()
+            && d.group().as_ref() == Some(&partial_id.group)
+            && let Some(v) = d.version()
         {
             version = Some(v.to_string());
         }

--- a/src/config/config_structs.rs
+++ b/src/config/config_structs.rs
@@ -1,4 +1,4 @@
-use crate::config::ConfigError;
+use crate::{config::ConfigError, maven_central::pom::Scope};
 use std::{collections::HashMap, path::PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -102,15 +102,18 @@ pub struct ConfigSetup {
 pub struct ConfigDependancy {
     pub group: String,
     pub version: String,
+    pub scope: Option<Scope>,
 }
 
 impl<'a> ConfigDependancyTomlEditView<'a> {
     pub fn to_config_dependancy(&self) -> Result<ConfigDependancy, ConfigError> {
         let group = assert(self.group(), "group_id")?;
         let version = assert(self.version(), "version")?;
+        let scope = self.scope();
         Ok(ConfigDependancy {
             group,
             version,
+            scope,
         })
     }
 }
@@ -121,6 +124,10 @@ pub struct ConfigResources {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(default)]
     pub exclude: Vec<String>,
+
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub external: Vec<String>,
 }
 
 fn is_default<T: Default + PartialEq>(value: &T) -> bool {

--- a/src/config/config_structs.rs
+++ b/src/config/config_structs.rs
@@ -89,6 +89,10 @@ pub struct ConfigSetup {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub main_class: Option<String>,
 
+    /// JDK release version passed to `javac --release` (e.g. "17")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub release: Option<String>,
+
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub exclude: Vec<String>,
 }

--- a/src/generate/pom.rs
+++ b/src/generate/pom.rs
@@ -12,7 +12,7 @@ use crate::{
         AnnotationProcessorPaths, Build, Configuration, DependancyType, Dependencies, Dependency,
         MavenPom, Plugin, Plugins, ProcessorPath, Properties, Scope,
     },
-    utils::{IOError, XmlSerializeError, fs},
+    utils::{IOError, XmlSerializeError, fs, jdk_version::desired_jdk_version},
 };
 
 pub fn generate_pom(ctx: &Context) -> Result<(), GenerateError> {
@@ -38,6 +38,8 @@ fn create_pom(ctx: &Context) -> Result<MavenPom, GenerateError> {
     let group_id = assert(project.group(), "group")?;
     let artifact_id = assert(project.artifact(), "artifact")?;
     let version_id = assert(project.version(), "version")?;
+
+    let jdk = desired_jdk_version(None, Some(ctx));
 
     if ctx.config.processors().is_some_and(|p| !p.is_empty()) {
         eprintln!(
@@ -115,7 +117,7 @@ fn create_pom(ctx: &Context) -> Result<MavenPom, GenerateError> {
         dependencies: Some(dependancies),
         dependency_management: None,
         properties: Properties {
-            map: HashMap::new(),
+            map: HashMap::from([("maven.compiler.release".to_string(), jdk)]),
         },
         parent: None,
         build,

--- a/src/import/pom.rs
+++ b/src/import/pom.rs
@@ -9,7 +9,7 @@ use colored::Colorize;
 use crate::{
     args::ImportPomArgs,
     config::ConfigTomlEdit,
-    maven_central::pom::MavenPom,
+    maven_central::{fetch_artifact_metadata, pom::MavenPom},
     utils::{IOError, XmlDeserializeError, fs},
 };
 
@@ -48,13 +48,6 @@ pub fn import_pom(root: &Path, args: &ImportPomArgs) -> Result<(), ImportError> 
     let mgmt_map = dep_mgmt_map(&pom);
 
     let mut config = ConfigTomlEdit::parse("")?;
-    {
-        let mut p = config.project_mut().get_or_insert_empty();
-        p.name_mut().set(pom.artifact_id.clone());
-        p.group_mut().set(pom.group_id.clone());
-        p.artifact_mut().set(pom.artifact_id.clone());
-        p.version_mut().set(pom.version.clone());
-    }
     if let Some(deps) = pom.dependencies {
         let mut tomldeps = config.dependancies_mut().get_or_insert(HashMap::new());
         for dep in deps.dependency {
@@ -66,13 +59,20 @@ pub fn import_pom(root: &Path, args: &ImportPomArgs) -> Result<(), ImportError> 
                     match mgmt_map.get(&hasher.finish()) {
                         Some(v) => v.clone(),
                         None => {
-                            eprintln!(
-                                "{} Skipping {}:{} — no version in dep or dependencyManagement",
-                                "Warning:".yellow().bold(),
-                                dep.group_id,
-                                dep.artifact_id,
-                            );
-                            continue;
+                            if let Ok(meta) =
+                                fetch_artifact_metadata(&dep.group_id, &dep.artifact_id)
+                                && let Some(latest) = meta.get_latest_version()
+                            {
+                                latest.to_string()
+                            } else {
+                                eprintln!(
+                                    "{} Skipping {}:{} — no version in dep or dependencyManagement and cannot resolve maven artifact",
+                                    "Warning:".yellow().bold(),
+                                    dep.group_id,
+                                    dep.artifact_id,
+                                );
+                                continue;
+                            }
                         }
                     }
                 }
@@ -80,12 +80,40 @@ pub fn import_pom(root: &Path, args: &ImportPomArgs) -> Result<(), ImportError> 
             let mut entry = tomldeps.insert_empty(&dep.artifact_id);
             entry.group_mut().set(dep.group_id.clone());
             entry.version_mut().set(version);
+            entry.scope_mut().set(dep.scope);
         }
+    }
+
+    if !args.only_dependencies {
+        {
+            let mut p = config.project_mut().get_or_insert_empty();
+            p.name_mut().set(pom.artifact_id.clone());
+            p.group_mut().set(pom.group_id.clone());
+            p.artifact_mut().set(pom.artifact_id.clone());
+            p.version_mut().set(pom.version.clone());
+        }
+
+        if let Some(version) = pom.properties.map.get("java.version") {
+            let mut v = config.setup_mut().get_or_insert_empty();
+            v.release_mut().replace(version.to_string());
+        }
+        config
+            .setup_mut()
+            .get_or_insert_empty()
+            .src_mut()
+            .replace("src/main/java".to_string());
+
+        config
+            .resources_mut()
+            .get_or_insert_empty()
+            .external_mut()
+            .replace(vec!["src/main/resources/**".to_string()]);
     }
 
     let toml_str = config.to_toml_string();
 
-    fs::write(&toml_path, toml_str).map_err(|e| IOError::new("writing lazy-java.toml", toml_path, e))?;
+    fs::write(&toml_path, toml_str)
+        .map_err(|e| IOError::new("writing lazy-java.toml", toml_path, e))?;
     println!("{} lazy-java.toml from pom.xml", "Imported".green().bold());
 
     Ok(())

--- a/src/import/tests.rs
+++ b/src/import/tests.rs
@@ -30,6 +30,7 @@ name = "original""#,
         &ImportPomArgs {
             pom_path: "pom.xml".into(),
             overwrite: false,
+            only_dependencies: false,
         },
     )
     .unwrap();
@@ -65,6 +66,7 @@ name = "original""#,
         &ImportPomArgs {
             pom_path: "pom.xml".into(),
             overwrite: true,
+            only_dependencies: false,
         },
     )
     .unwrap();

--- a/src/lock_file/lock_file.rs
+++ b/src/lock_file/lock_file.rs
@@ -123,7 +123,13 @@ impl LockFile {
                 let old_version = Maven3ArtifactVersion::new(&old.id.version);
                 let new_version = Maven3ArtifactVersion::new(&package.id.version);
 
-                if (new_version > old_version || package.root) && !old.root {
+                let replaces = if old.root {
+                    package.root && new_version > old_version
+                } else {
+                    package.root || new_version > old_version
+                };
+
+                if replaces {
                     map.insert(hash, package);
                 } else {
                     map.insert(hash, old);

--- a/src/lock_file/lock_file.rs
+++ b/src/lock_file/lock_file.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use colored::Colorize;
+use log::info;
 use maven_version::Maven3ArtifactVersion;
 use serde::{Deserialize, Serialize};
 
@@ -17,7 +18,7 @@ use crate::{
         MavenId, MavenIdBuf, PartialMavenIdBuf,
         pom::{DependancyType, MavenDependancyList, Scope},
     },
-    utils::{fs, IOError, TomlDeserializeError, TomlSerializeError},
+    utils::{IOError, TomlDeserializeError, TomlSerializeError, fs},
 };
 
 #[derive(Serialize, Deserialize)]
@@ -55,7 +56,10 @@ impl LockFile {
     pub fn fetch(root: &Path) -> Result<LockFile, LockFileError> {
         let fs_file = Self::fetch_from_fs(root)?;
         let lock = match fs_file {
-            None => LockFile::new(),
+            None => {
+                log::info!("Creating lock file from new");
+                LockFile::new()
+            }
             Some(l) => l,
         };
         Ok(lock)
@@ -91,8 +95,12 @@ impl LockFile {
 
         Ok(())
     }
-    pub fn add_package(&mut self, id: MavenIdBuf) -> Result<isize, LockFileError> {
-        let list: Vec<LockFilePackage> = MavenDependancyList::new(id)?
+    pub fn add_package(
+        &mut self,
+        id: MavenIdBuf,
+        scope: Option<Scope>,
+    ) -> Result<isize, LockFileError> {
+        let list: Vec<LockFilePackage> = MavenDependancyList::new(id, scope)?
             .into_iter()
             .map(|m| m.into())
             .collect();
@@ -115,7 +123,7 @@ impl LockFile {
                 let old_version = Maven3ArtifactVersion::new(&old.id.version);
                 let new_version = Maven3ArtifactVersion::new(&package.id.version);
 
-                if new_version > old_version {
+                if (new_version > old_version || package.root) && !old.root {
                     map.insert(hash, package);
                 } else {
                     map.insert(hash, old);
@@ -183,8 +191,7 @@ impl LockFile {
         removed += Self::validate_dir(&ctx.lib, &mut map)?;
         removed += Self::validate_dir(&ctx.lib_annotations, &mut map)?;
 
-        let download_change =
-            Self::fetch_packages(ctx, map.into_values().collect())?;
+        let download_change = Self::fetch_packages(ctx, map.into_values().collect())?;
         added += download_change;
 
         let plural = |change: isize| {
@@ -224,7 +231,8 @@ impl LockFile {
         for (key, package) in root_packages {
             if !map.contains(key) {
                 let id = key.clone().to_full_buf(package.version.clone());
-                self.add_package(id)?;
+                info!("Adding package '{}'", id);
+                self.add_package(id, package.scope)?;
             }
         }
 

--- a/src/lock_file/remove.rs
+++ b/src/lock_file/remove.rs
@@ -3,7 +3,7 @@ use std::{
     mem,
 };
 
-use log::debug;
+use log::info;
 
 use crate::{
     lock_file::{LockFile, LockFileError, LockFilePackage},
@@ -23,7 +23,7 @@ impl LockFile {
 
         if let Some(pos) = pos {
             let package = self.packages.remove(pos);
-            debug!("Removed package {}", package.id);
+            info!("Removed package {}", package.id);
 
             self.packages.iter_mut().for_each(|p| {
                 p.dependancies.retain(|dep| dep != &package.id);

--- a/src/lsp/classpath_impl.rs
+++ b/src/lsp/classpath_impl.rs
@@ -16,7 +16,7 @@ use crate::{
         classpath::{Attribute, Attributes, Classpath, ClasspathEntry},
         classpath_error::ClasspathError,
     },
-    utils::fs,
+    utils::{fs, jdk_version::desired_jdk_version},
 };
 
 const JAVA_CONTAINER: &str = "org.eclipse.jdt.launching.JRE_CONTAINER";
@@ -98,9 +98,12 @@ impl Classpath {
             attributes: None,
         });
 
+        let version = desired_jdk_version(None, Some(ctx));
         entries.push(ClasspathEntry {
             kind: "con".into(),
-            path: JAVA_CONTAINER.into(),
+            path: format!(
+                "{JAVA_CONTAINER}/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-{version}"
+            ),
             including: None,
             output: None,
             attributes: None,

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -11,7 +11,7 @@ use crate::{Context, lazy_java_error::LazyJavaError, lsp::classpath::Classpath};
 
 pub fn sync_lsp_config(ctx: &Context) -> Result<(), LazyJavaError> {
     Classpath::generate_if_stale(ctx)?;
-    DotSettings::generate(&ctx.root)?;
+    DotSettings::generate(ctx)?;
     DotProject::generate(ctx)?;
 
     Ok(())

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -1,25 +1,25 @@
-use std::{
-    io,
-    path::Path,
-};
+use std::io;
 
-use crate::utils::fs;
+use crate::{Context, utils::fs, utils::jdk_version::desired_jdk_version};
 
 pub struct DotSettings {}
 
 impl DotSettings {
-    pub fn generate(root: &Path) -> Result<(), io::Error> {
+    pub fn generate(ctx: &Context) -> Result<(), io::Error> {
+        let root = &ctx.root;
+        let version = desired_jdk_version(None, Some(ctx));
         let dot_settings = root.join(".settings");
         if !fs::exists(&dot_settings)? {
             fs::create_dir(&dot_settings)?;
         }
         fs::write(
             root.join(".settings/org.eclipse.core.prefs"),
-            r#"eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.source=25
-org.eclipse.jdt.core.compiler.compliance=25
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=25
-"#,
+            format!(
+                "eclipse.preferences.version=1\n\
+                 org.eclipse.jdt.core.compiler.source={version}\n\
+                 org.eclipse.jdt.core.compiler.compliance={version}\n\
+                 org.eclipse.jdt.core.compiler.codegen.targetPlatform={version}\n"
+            ),
         )
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,6 @@ fn main() -> Result<()> {
     };
 
     env_logger::builder()
-        .format_target(cfg!(debug_assertions))
         .filter_level(log_level)
         .format_timestamp(None)
         .init();

--- a/src/maven_central/fetch_async.rs
+++ b/src/maven_central/fetch_async.rs
@@ -5,7 +5,7 @@ use crate::{
 use reqwest::{Client, Response};
 
 pub async fn fetch_jar(client: Client, id: &MavenId<'_>) -> Result<Vec<u8>, MavenError> {
-    log::info!("Fetching JAR for {}", id);
+    log::debug!("Fetching JAR for {}", id);
     let res = get_from_maven(client, id, "jar").await?;
 
     let bytes = res.bytes().await?.to_vec();
@@ -14,7 +14,7 @@ pub async fn fetch_jar(client: Client, id: &MavenId<'_>) -> Result<Vec<u8>, Mave
 }
 
 pub async fn fetch_pom(client: Client, id: &MavenId<'_>) -> Result<MavenPom, MavenError> {
-    log::info!("Fetching POM for {}", id);
+    log::debug!("Fetching POM for {}", id);
     let res = get_from_maven(client, id, "pom").await?;
 
     let text = res.text().await?;

--- a/src/maven_central/pom/dependancy_list.rs
+++ b/src/maven_central/pom/dependancy_list.rs
@@ -6,7 +6,7 @@ use std::{
     sync::{Arc, LazyLock},
 };
 
-use log::{debug, warn};
+use log::{debug, trace};
 use maven_version::Maven3ArtifactVersion;
 use regex::{Regex, RegexBuilder};
 use tokio::{
@@ -35,7 +35,10 @@ struct ResolveContext {
 }
 
 impl MavenDependancyList {
-    async fn runtime_entry(id: MavenIdBuf) -> Result<Vec<MavenDependancy>, MavenError> {
+    async fn runtime_entry(
+        id: MavenIdBuf,
+        scope: Option<Scope>,
+    ) -> Result<Vec<MavenDependancy>, MavenError> {
         log::info!("Creating POM list for {}", id);
 
         let cache = Arc::new(RwLock::new(HashMap::new()));
@@ -47,7 +50,7 @@ impl MavenDependancyList {
             list: dep_list.clone(),
             client,
         };
-        Self::resolve_pom(id.clone(), ctx).await?;
+        Self::resolve_pom(id.clone(), ctx, scope).await?;
 
         let mut map: HashMap<u64, MavenDependancy> = HashMap::new();
 
@@ -79,12 +82,16 @@ impl MavenDependancyList {
         }
         Ok(list)
     }
-    pub fn new(id: MavenIdBuf) -> Result<Vec<MavenDependancy>, MavenError> {
+    pub fn new(id: MavenIdBuf, scope: Option<Scope>) -> Result<Vec<MavenDependancy>, MavenError> {
         let rt = Runtime::new().unwrap();
 
-        rt.block_on(Self::runtime_entry(id))
+        rt.block_on(Self::runtime_entry(id, scope))
     }
-    async fn resolve_pom(id: MavenIdBuf, ctx: ResolveContext) -> Result<Arc<MavenPom>, MavenError> {
+    async fn resolve_pom(
+        id: MavenIdBuf,
+        ctx: ResolveContext,
+        scope: Option<Scope>,
+    ) -> Result<Arc<MavenPom>, MavenError> {
         log::debug!("Resolving POM for {}", id);
         let hash = Self::hash_maven_id(&id.as_maven_id());
 
@@ -153,43 +160,45 @@ impl MavenDependancyList {
             Self::resolve_properties_inital(&mut pom);
         }
 
-        let bom_handles = Self::bom_handles(&pom, &ctx);
-        if let Some(mut bom_handles) = bom_handles {
-            while let Some(result) = bom_handles.join_next().await {
-                let bom_pom = result??;
-                log::debug!(
-                    "Found BOM import: {}:{}:{} for {}",
-                    bom_pom.group_id,
-                    bom_pom.artifact_id,
-                    bom_pom.version,
-                    id
-                );
-                // extend properties
-                let mut bom_props = bom_pom.properties.map.clone();
-                bom_props.extend(pom.properties.map);
-                pom.properties.map = bom_props;
-
-                // backwords
-                pom.dependency_management_map
-                    .extend(bom_pom.dependency_management_map.clone());
-            }
-        }
-
-        Self::resolve_properties_inital(&mut pom);
-
-        // tracks the dep list for the dependancy list
         let mut dependancy_list: Vec<Dependancy> = Vec::new();
 
-        let dependacy_handles = Self::dependancy_handles(&pom, &ctx);
-        if let Some(mut dependacy_handles) = dependacy_handles {
-            while let Some(result) = dependacy_handles.join_next().await {
-                let (dep_result, id) = result?;
-                let dep_pom = dep_result?;
-                let mut dep_props = dep_pom.properties.map.clone();
-                dep_props.extend(pom.properties.map);
-                pom.properties.map = dep_props;
+        if scope != Some(Scope::Provided) {
+            let bom_handles = Self::bom_handles(&pom, &ctx);
+            if let Some(mut bom_handles) = bom_handles {
+                while let Some(result) = bom_handles.join_next().await {
+                    let bom_pom = result??;
+                    log::debug!(
+                        "Found BOM import: {}:{}:{} for {}",
+                        bom_pom.group_id,
+                        bom_pom.artifact_id,
+                        bom_pom.version,
+                        id
+                    );
+                    // extend properties
+                    let mut bom_props = bom_pom.properties.map.clone();
+                    bom_props.extend(pom.properties.map);
+                    pom.properties.map = bom_props;
 
-                dependancy_list.push(Dependancy { id });
+                    // backwords
+                    pom.dependency_management_map
+                        .extend(bom_pom.dependency_management_map.clone());
+                }
+            }
+            Self::resolve_properties_inital(&mut pom);
+
+            // tracks the dep list for the dependancy list
+
+            let dependacy_handles = Self::dependancy_handles(&pom, &ctx);
+            if let Some(mut dependacy_handles) = dependacy_handles {
+                while let Some(result) = dependacy_handles.join_next().await {
+                    let (dep_result, id) = result?;
+                    let dep_pom = dep_result?;
+                    let mut dep_props = dep_pom.properties.map.clone();
+                    dep_props.extend(pom.properties.map);
+                    pom.properties.map = dep_props;
+
+                    dependancy_list.push(Dependancy { id });
+                }
             }
         }
 
@@ -295,7 +304,7 @@ impl MavenDependancyList {
             let owned_id: MavenIdBuf =
                 MavenIdBuf::new(&parent.group_id, &parent.artifact_id, &parent.version);
 
-            let handle = spawn(async move { Self::resolve_pom(owned_id, ctx_clone).await });
+            let handle = spawn(async move { Self::resolve_pom(owned_id, ctx_clone, None).await });
             return Some(handle);
         }
         None
@@ -307,14 +316,16 @@ impl MavenDependancyList {
         if let Some(dep_management) = &pom.dependency_management {
             let mut set: JoinSet<Result<Arc<MavenPom>, MavenError>> = JoinSet::new();
             for dep in &dep_management.dependencies.dependency {
-                let scope = &dep.scope;
-                if *scope == Scope::Import && !dep.optional {
+                let scope = dep.scope;
+                if scope == Scope::Import && !dep.optional {
                     let bom_version = dep.version.as_ref().expect("Bom is missing version");
                     let id = MavenId::new(&dep.group_id, &dep.artifact_id, bom_version);
 
                     let ctx_clone = ctx.clone();
                     let owned_id: MavenIdBuf = id.into();
-                    set.spawn(async move { Self::resolve_pom(owned_id, ctx_clone).await });
+                    set.spawn(
+                        async move { Self::resolve_pom(owned_id, ctx_clone, Some(scope)).await },
+                    );
                 }
             }
             return Some(set);
@@ -329,7 +340,9 @@ impl MavenDependancyList {
             let mut set = JoinSet::new();
             for dep in &deps.dependency {
                 let scope = &dep.scope;
-                if ![Scope::Compile, Scope::Runtime].contains(scope) || dep.optional {
+                if ![Scope::Compile, Scope::Runtime, Scope::Provided].contains(scope)
+                    || dep.optional
+                {
                     continue;
                 }
 
@@ -353,9 +366,10 @@ impl MavenDependancyList {
                 let owned_id: MavenIdBuf =
                     MavenIdBuf::new(dep.group_id.clone(), dep.artifact_id.clone(), dep_version);
 
+                let scope = *scope;
                 set.spawn(async move {
                     (
-                        Self::resolve_pom(owned_id.clone(), ctx_clone).await,
+                        Self::resolve_pom(owned_id.clone(), ctx_clone, Some(scope)).await,
                         owned_id,
                     )
                 });
@@ -392,7 +406,7 @@ fn resolve_string_final(label: &mut String, map: &HashMap<String, String>) {
             if let Some(property) = map.get(capture.as_str()) {
                 replaced = replaced.replace(&format!("${{{}}}", capture.as_str()), property);
             } else {
-                warn!(
+                trace!(
                     "Property found in field but not present in map, property: {}",
                     capture.as_str()
                 );

--- a/src/maven_central/pom/pom.rs
+++ b/src/maven_central/pom/pom.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use strum::AsRefStr;
+use strum::{AsRefStr, EnumString};
+use toml_edit_derive::TomlEdit;
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename = "project")]
@@ -83,9 +84,22 @@ pub struct Properties {
     pub map: HashMap<String, String>,
 }
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Hash, Default, PartialOrd, Ord,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Deserialize,
+    Serialize,
+    Hash,
+    Default,
+    PartialOrd,
+    Ord,
+    TomlEdit,
+    EnumString,
 )]
 #[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
 pub enum Scope {
     #[default]
     Compile,

--- a/src/maven_central/pom/pom_deserialize.rs
+++ b/src/maven_central/pom/pom_deserialize.rs
@@ -12,7 +12,7 @@ impl MavenPom {
     pub fn deserialize(id: &MavenId, content: &str) -> Result<MavenPom, MavenError> {
         let mut pom: MavenPom = quick_xml::de::from_str(content)
             .map_err(|e| XmlDeserializeError::new("parsing pom", id.to_string(), e))?;
-        log::info!("Successfully parsed POM {}", id);
+        log::debug!("Successfully parsed POM {}", id);
 
         pom.group_id = id.group.to_string();
         pom.version = id.version.to_string();

--- a/src/maven_central/pom/tests.rs
+++ b/src/maven_central/pom/tests.rs
@@ -19,7 +19,7 @@ mod tests {
     #[test]
     fn test_maven_dependancy_list_simple() {
         // Test creating a dependency list for a simple artifact (junit has no dependencies)
-        let result = MavenDependancyList::new(MavenIdBuf::new("junit", "junit", "4.13.2"));
+        let result = MavenDependancyList::new(MavenIdBuf::new("junit", "junit", "4.13.2"), None);
         assert!(
             result.is_ok(),
             "Failed to create dependency list: {:?}",
@@ -46,7 +46,7 @@ mod tests {
             "com.fasterxml.jackson.core",
             "jackson-databind",
             "2.15.0",
-        ));
+        ), None);
         assert!(
             result.is_ok(),
             "Failed to create dependency list: {:?}",
@@ -73,7 +73,7 @@ mod tests {
             "invalid.id.group",
             "invalid.id.artifact",
             "1.0.0",
-        ));
+        ), None);
         assert!(result.is_err(), "Should fail for non-existent artifact");
     }
 
@@ -81,7 +81,7 @@ mod tests {
     fn test_maven_dependancy_list_against_real_list() {
         // Test that transitive dependencies are included
         let result =
-            MavenDependancyList::new(MavenIdBuf::new("com.google.guava", "guava", "33.6.0-jre"));
+            MavenDependancyList::new(MavenIdBuf::new("com.google.guava", "guava", "33.6.0-jre"), None);
         assert!(result.is_ok());
 
         let mut dep_list = result.unwrap();
@@ -154,7 +154,7 @@ mod tests {
             "org.springframework.boot",
             "spring-boot-starter-web",
             "4.1.0-RC1",
-        ));
+        ), None);
         assert!(result.is_ok());
 
         let dep_list = result.unwrap();
@@ -183,7 +183,7 @@ mod tests {
     fn test_maven_dependancy_list_versions_valid() {
         // Test that all versions in the list are valid version strings
         let result =
-            MavenDependancyList::new(MavenIdBuf::new("com.google.guava", "guava", "31.1-jre"));
+            MavenDependancyList::new(MavenIdBuf::new("com.google.guava", "guava", "31.1-jre"), None);
         assert!(result.is_ok());
 
         let dep_list = result.unwrap();
@@ -203,7 +203,7 @@ mod tests {
     #[test]
     fn test_maven_dependancy_list_root_artifact_included() {
         // Test that the root artifact is included in the dependency list
-        let result = MavenDependancyList::new(MavenIdBuf::new("junit", "junit", "4.13.2"));
+        let result = MavenDependancyList::new(MavenIdBuf::new("junit", "junit", "4.13.2"), None);
         assert!(result.is_ok());
 
         let dep_list = result.unwrap();
@@ -222,7 +222,7 @@ mod tests {
     fn test_maven_dependancy_list_dependency_types() {
         // Test that dependencies have valid packaging types
         let result =
-            MavenDependancyList::new(MavenIdBuf::new("com.google.guava", "guava", "31.1-jre"));
+            MavenDependancyList::new(MavenIdBuf::new("com.google.guava", "guava", "31.1-jre"), None);
         assert!(result.is_ok());
 
         let dep_list = result.unwrap();

--- a/src/maven_central/pom/tests.rs
+++ b/src/maven_central/pom/tests.rs
@@ -42,11 +42,10 @@ mod tests {
     #[test]
     fn test_maven_dependancy_list_excludes_pom_packaging() {
         // Test that POM-type dependencies are excluded from the list
-        let result = MavenDependancyList::new(MavenIdBuf::new(
-            "com.fasterxml.jackson.core",
-            "jackson-databind",
-            "2.15.0",
-        ), None);
+        let result = MavenDependancyList::new(
+            MavenIdBuf::new("com.fasterxml.jackson.core", "jackson-databind", "2.15.0"),
+            None,
+        );
         assert!(
             result.is_ok(),
             "Failed to create dependency list: {:?}",
@@ -69,19 +68,20 @@ mod tests {
     #[test]
     fn test_maven_dependancy_list_invalid_artifact() {
         // Test that invalid artifacts produce errors
-        let result = MavenDependancyList::new(MavenIdBuf::new(
-            "invalid.id.group",
-            "invalid.id.artifact",
-            "1.0.0",
-        ), None);
+        let result = MavenDependancyList::new(
+            MavenIdBuf::new("invalid.id.group", "invalid.id.artifact", "1.0.0"),
+            None,
+        );
         assert!(result.is_err(), "Should fail for non-existent artifact");
     }
 
     #[test]
     fn test_maven_dependancy_list_against_real_list() {
         // Test that transitive dependencies are included
-        let result =
-            MavenDependancyList::new(MavenIdBuf::new("com.google.guava", "guava", "33.6.0-jre"), None);
+        let result = MavenDependancyList::new(
+            MavenIdBuf::new("com.google.guava", "guava", "33.6.0-jre"),
+            None,
+        );
         assert!(result.is_ok());
 
         let mut dep_list = result.unwrap();
@@ -150,11 +150,14 @@ mod tests {
     #[test]
     fn test_maven_dependancy_list_no_duplicates() {
         // Test that the list doesn't have duplicate entries
-        let result = MavenDependancyList::new(MavenIdBuf::new(
-            "org.springframework.boot",
-            "spring-boot-starter-web",
-            "4.1.0-RC1",
-        ), None);
+        let result = MavenDependancyList::new(
+            MavenIdBuf::new(
+                "org.springframework.boot",
+                "spring-boot-starter-web",
+                "4.1.0-RC1",
+            ),
+            None,
+        );
         assert!(result.is_ok());
 
         let dep_list = result.unwrap();
@@ -182,8 +185,10 @@ mod tests {
     #[test]
     fn test_maven_dependancy_list_versions_valid() {
         // Test that all versions in the list are valid version strings
-        let result =
-            MavenDependancyList::new(MavenIdBuf::new("com.google.guava", "guava", "31.1-jre"), None);
+        let result = MavenDependancyList::new(
+            MavenIdBuf::new("com.google.guava", "guava", "31.1-jre"),
+            None,
+        );
         assert!(result.is_ok());
 
         let dep_list = result.unwrap();
@@ -221,8 +226,10 @@ mod tests {
     #[test]
     fn test_maven_dependancy_list_dependency_types() {
         // Test that dependencies have valid packaging types
-        let result =
-            MavenDependancyList::new(MavenIdBuf::new("com.google.guava", "guava", "31.1-jre"), None);
+        let result = MavenDependancyList::new(
+            MavenIdBuf::new("com.google.guava", "guava", "31.1-jre"),
+            None,
+        );
         assert!(result.is_ok());
 
         let dep_list = result.unwrap();

--- a/src/run/run_java.rs
+++ b/src/run/run_java.rs
@@ -1,15 +1,22 @@
-use std::process::{Command, Stdio};
+use std::io;
+use std::process::Stdio;
 
 use colored::Colorize;
 
 use crate::{
-    Context,
-    args::RunArgs,
-    lazy_java::LazyJava,
-    lazy_java_error::LazyJavaError,
-    run::{RunError, interactive_run::interactive_find_main},
-    utils::{GlobalContext, IOError, processes::execute_java},
-};
+        Context,
+        args::RunArgs,
+        build::BuildError,
+        build::metadata::BuildMetadata,
+        lazy_java::LazyJava,
+        lazy_java_error::LazyJavaError,
+        run::{RunError, interactive_run::interactive_find_main},
+        utils::{
+            GlobalContext, IOError,
+            jdk_version::warn_runtime_mismatch,
+            processes::{execute_java, java_tool_command},
+        },
+    };
 
 impl LazyJava {
     pub fn run(args: &RunArgs, ctx: &Context) -> Result<(), LazyJavaError> {
@@ -30,8 +37,13 @@ impl LazyJava {
         };
         println!("{} {}", "Running".bold().green(), class);
 
-        execute_java(class, &ctx.bin, &ctx.lib, &args.args)
-            .map_err(|_e| RunError::InvalidMainClass(class.to_string()))?;
+        if let Some(meta) = BuildMetadata::fetch(&ctx.target)
+            && !meta.java_version.is_empty()
+        {
+            warn_runtime_mismatch(&meta.java_version);
+        }
+
+        execute_java(class, &ctx.bin, &ctx.lib, &args.args)?;
 
         log::info!("Java execution completed successfully");
         Ok(())
@@ -50,7 +62,7 @@ impl LazyJava {
             return Ok(());
         }
 
-        let status = Command::new("java")
+        let status = java_tool_command("java")
             .arg("-jar")
             .arg(&jar_path)
             .args(&args.args)
@@ -58,7 +70,13 @@ impl LazyJava {
             .stderr(Stdio::inherit())
             .stdin(Stdio::inherit())
             .status()
-            .map_err(|e| RunError::IoError(IOError::new("executing jar", &jar_path, e)))?;
+            .map_err(|e| {
+                if e.kind() == io::ErrorKind::NotFound {
+                    RunError::BuildError(BuildError::JavaNotFound)
+                } else {
+                    RunError::IoError(IOError::new("executing jar", &jar_path, e))
+                }
+            })?;
 
         if !status.success() {
             log::warn!("jar exited with code: {:?}", status.code());

--- a/src/run/run_java.rs
+++ b/src/run/run_java.rs
@@ -4,19 +4,19 @@ use std::process::Stdio;
 use colored::Colorize;
 
 use crate::{
-        Context,
-        args::RunArgs,
-        build::BuildError,
-        build::metadata::BuildMetadata,
-        lazy_java::LazyJava,
-        lazy_java_error::LazyJavaError,
-        run::{RunError, interactive_run::interactive_find_main},
-        utils::{
-            GlobalContext, IOError,
-            jdk_version::warn_runtime_mismatch,
-            processes::{execute_java, java_tool_command},
-        },
-    };
+    Context,
+    args::RunArgs,
+    build::BuildError,
+    build::metadata::BuildMetadata,
+    lazy_java::LazyJava,
+    lazy_java_error::LazyJavaError,
+    run::{RunError, interactive_run::interactive_find_main},
+    utils::{
+        GlobalContext, IOError,
+        jdk_version::warn_runtime_mismatch,
+        processes::{execute_java, java_tool_command},
+    },
+};
 
 impl LazyJava {
     pub fn run(args: &RunArgs, ctx: &Context) -> Result<(), LazyJavaError> {

--- a/src/utils/context/context.rs
+++ b/src/utils/context/context.rs
@@ -13,7 +13,7 @@ use crate::{
     lazy_java_error::LazyJavaError,
     lock_file::LockFile,
     lsp::sync_lsp_config,
-    utils::{IOError, find_root::find_root, fs, GlobalContext},
+    utils::{GlobalContext, IOError, find_root::find_root, fs},
 };
 
 use super::ContextError;

--- a/src/utils/jdk_version.rs
+++ b/src/utils/jdk_version.rs
@@ -126,4 +126,3 @@ mod tests {
         assert_eq!(parse_major("javac something"), None);
     }
 }
-

--- a/src/utils/jdk_version.rs
+++ b/src/utils/jdk_version.rs
@@ -1,0 +1,129 @@
+use std::sync::OnceLock;
+
+use colored::Colorize;
+
+use crate::{Context, args::BuildArgs, utils::processes::java_tool_command};
+
+/// Default JDK release used when the installed Java version cannot be detected.
+pub const DEFAULT_RELEASE: &str = "25";
+
+static INSTALLED_VERSION: OnceLock<String> = OnceLock::new();
+
+/// The desired JDK release version for the build.
+///
+/// Resolution order:
+/// 1. `--release` from CLI [`BuildArgs`]
+/// 2. `[setup] release` from the project's config
+/// 3. The major version of the installed JDK (via `java -version`), resolved
+///    once and cached.
+/// 4. [`DEFAULT_RELEASE`] with a warning, if detection fails.
+pub fn desired_jdk_version(args: Option<&BuildArgs>, ctx: Option<&Context>) -> String {
+    if let Some(args) = args
+        && let Some(version) = &args.release
+    {
+        return version.trim().to_string();
+    }
+
+    if let Some(ctx) = ctx
+        && let Some(setup) = ctx.config.setup()
+        && let Some(version) = setup.release()
+    {
+        return version;
+    }
+
+    installed_jdk_version()
+}
+
+/// The major version of the installed JDK, resolved once and cached.
+pub fn installed_jdk_version() -> String {
+    INSTALLED_VERSION
+        .get_or_init(detect_installed_version)
+        .clone()
+}
+
+/// Warn if the installed JDK is older than the release the project was
+/// compiled for, since the compiled classes may then fail to run.
+pub fn warn_runtime_mismatch(release: &str) {
+    let runtime = installed_jdk_version();
+    match (runtime.parse::<i64>(), release.trim().parse::<i64>()) {
+        (Ok(runtime), Ok(release)) if runtime < release => {
+            println!(
+                "{}: The installed JDK is {runtime} but the project targets JDK {release}. \
+                 Compiled classes may not run; install a JDK >= {release}.",
+                "Warning".yellow().bold()
+            );
+        }
+        _ => {}
+    }
+}
+
+fn detect_installed_version() -> String {
+    let output = match java_tool_command("java").arg("-version").output() {
+        Ok(output) => output,
+        Err(e) => {
+            warn_and_default(&format!("could not run java -version: {e}"));
+            return DEFAULT_RELEASE.to_string();
+        }
+    };
+
+    let raw = String::from_utf8_lossy(&output.stderr);
+    let raw = raw.trim();
+    log::debug!("java -version output: {}", raw);
+
+    match parse_major(raw) {
+        Some(major) => major,
+        None => {
+            warn_and_default(&format!("could not parse java version from: {raw}"));
+            DEFAULT_RELEASE.to_string()
+        }
+    }
+}
+
+fn warn_and_default(reason: &str) {
+    println!(
+        "{}: {reason}; defaulting to JDK release {DEFAULT_RELEASE}. \
+         Set `--release` or `[setup] release` to use a specific version.",
+        "Warning".yellow().bold()
+    );
+}
+
+/// Extract the major version from `java -version` output. Handles both the
+/// modern (`"21.0.1"`) and legacy (`"1.8.0_432"`) formats.
+fn parse_major(raw: &str) -> Option<String> {
+    let opening = raw.find('"')?;
+    let after = &raw[opening + 1..];
+    let closing = after.find('"')?;
+    let version = &after[..closing];
+
+    let major = if let Some(legacy) = version.strip_prefix("1.") {
+        legacy.split('.').next().unwrap_or(version)
+    } else {
+        version.split('.').next().unwrap_or(version)
+    };
+
+    Some(major.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_major;
+
+    #[test]
+    fn parses_modern_version() {
+        assert_eq!(
+            parse_major("openjdk version \"21.0.2\" 2026-04-21 LTS"),
+            Some("21".into())
+        );
+    }
+
+    #[test]
+    fn parses_legacy_jdk8() {
+        assert_eq!(parse_major("java version \"1.8.0_432\""), Some("8".into()));
+    }
+
+    #[test]
+    fn returns_none_when_no_version() {
+        assert_eq!(parse_major("javac something"), None);
+    }
+}
+

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,7 @@
 pub mod find_main;
 pub mod find_root;
 pub mod fs;
+pub mod jdk_version;
 mod join_dir;
 pub mod processes;
 pub mod timings;

--- a/src/utils/processes.rs
+++ b/src/utils/processes.rs
@@ -6,10 +6,7 @@ use std::{
 
 use log::debug;
 
-use crate::{
-    JAVAC_SEPERATOR, build::BuildError, utils::IOError,
-};
-
+use crate::{JAVAC_SEPERATOR, build::BuildError, utils::IOError};
 
 /// Build a command for a JDK tool (`javac`, `jar`, `java`). Prefers the
 /// executable from `$JAVA_HOME/bin` and falls back to the system PATH.
@@ -26,8 +23,6 @@ pub fn java_tool_command(tool: &str) -> Command {
     }
     Command::new(tool)
 }
-
-
 
 fn run_command(
     build: &str,

--- a/src/utils/processes.rs
+++ b/src/utils/processes.rs
@@ -1,12 +1,33 @@
 use std::{
-    io,
+    env, io,
     path::{self, Path, PathBuf},
     process::{Command, ExitStatus, Output, Stdio},
 };
 
 use log::debug;
 
-use crate::JAVAC_SEPERATOR;
+use crate::{
+    JAVAC_SEPERATOR, build::BuildError, utils::IOError,
+};
+
+
+/// Build a command for a JDK tool (`javac`, `jar`, `java`). Prefers the
+/// executable from `$JAVA_HOME/bin` and falls back to the system PATH.
+pub fn java_tool_command(tool: &str) -> Command {
+    if let Some(home) = env::var_os("JAVA_HOME") {
+        let base = Path::new(&home).join("bin");
+        let mut candidate = base.join(tool);
+        if cfg!(windows) && candidate.extension().is_none() {
+            candidate.set_extension("exe");
+        }
+        if candidate.is_file() {
+            return Command::new(candidate);
+        }
+    }
+    Command::new(tool)
+}
+
+
 
 fn run_command(
     build: &str,
@@ -16,7 +37,7 @@ fn run_command(
 ) -> Result<Output, io::Error> {
     let sep = JAVAC_SEPERATOR;
 
-    let mut c = Command::new("java");
+    let mut c = java_tool_command("java");
     let command = c
         .args(["-classpath", &format!("{}{sep}{}/*", build, lib)])
         .arg(class)
@@ -36,7 +57,7 @@ pub fn execute_java(
     classpath: &PathBuf,
     lib: &Path,
     args: &Vec<String>,
-) -> Result<ExitStatus, io::Error> {
+) -> Result<ExitStatus, BuildError> {
     log::info!("Executing Java class: {}", classname);
     log::debug!("Using classpath: {:?}", classpath);
     log::debug!("Using library path: {:?}", lib);
@@ -44,8 +65,10 @@ pub fn execute_java(
         log::debug!("Program arguments: {:?}", args);
     }
 
-    let ab_classpath = path::absolute(classpath)?;
-    let ab_lib = path::absolute(lib)?;
+    let ab_classpath = path::absolute(classpath)
+        .map_err(|e| BuildError::IoError(IOError::new("resolving classpath", classpath, e)))?;
+    let ab_lib = path::absolute(lib)
+        .map_err(|e| BuildError::IoError(IOError::new("resolving library path", lib, e)))?;
 
     let output = run_command(
         ab_classpath.to_str().unwrap(),
@@ -53,7 +76,13 @@ pub fn execute_java(
         classname,
         args,
     )
-    .expect("Run Command Failed");
+    .map_err(|e| {
+        if e.kind() == io::ErrorKind::NotFound {
+            BuildError::JavaNotFound
+        } else {
+            BuildError::IoError(IOError::new("running java", &ab_classpath, e))
+        }
+    })?;
 
     if output.status.success() {
         log::info!("Java execution completed successfully");
@@ -65,31 +94,6 @@ pub fn execute_java(
     }
 
     Ok(output.status)
-}
-
-pub fn java_version() -> Result<String, io::Error> {
-    let command = "java --version";
-    let output = if cfg!(target_os = "windows") {
-        Command::new("powershell")
-            .args(["-Command", command])
-            .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit())
-            .output()
-    } else {
-        Command::new("sh")
-            .arg("-c")
-            .arg(command)
-            .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit())
-            .output()
-    }?;
-
-    let str = String::from_utf8_lossy(&output.stdout);
-    let mut split = str.split(" ");
-
-    let version = split.next().unwrap();
-
-    Ok(version.to_string())
 }
 
 #[cfg(test)]

--- a/test_filesystem/test10/.classpath
+++ b/test_filesystem/test10/.classpath
@@ -51,5 +51,5 @@
         </attributes>
     </classpathentry>
     <classpathentry kind="output" path="target/bin"/>
-    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-25"/>
 </classpath>

--- a/tests/fixtures/generate-pom/lazy-java.toml
+++ b/tests/fixtures/generate-pom/lazy-java.toml
@@ -3,3 +3,6 @@ name = "generate-pom"
 group = "com.example"
 artifact = "generate-pom"
 version = "2.0.0"
+
+[setup]
+release = "25"

--- a/tests/fixtures/jdk-version/lazy-java.toml
+++ b/tests/fixtures/jdk-version/lazy-java.toml
@@ -1,0 +1,5 @@
+[project]
+name = "jdk-release"
+
+[setup]
+release = "11"

--- a/tests/fixtures/jdk-version/src/Main.java
+++ b/tests/fixtures/jdk-version/src/Main.java
@@ -1,0 +1,5 @@
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("hello");
+    }
+}

--- a/tests/fixtures/resource-files/external.txt
+++ b/tests/fixtures/resource-files/external.txt
@@ -1,0 +1,1 @@
+External resource content

--- a/tests/fixtures/resource-files/lazy-java.toml
+++ b/tests/fixtures/resource-files/lazy-java.toml
@@ -3,3 +3,4 @@ name = "resource-files"
 
 [resources]
 exclude = ["**/secret.txt"]
+external = ["external.txt"]

--- a/tests/fixtures/resource-files/src/Main.java
+++ b/tests/fixtures/resource-files/src/Main.java
@@ -12,5 +12,12 @@ public class Main {
         BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
         String content = reader.readLine();
         System.out.println("Resource content: " + content);
+
+        InputStream ext = Main.class.getResourceAsStream("/external.txt");
+        if (ext == null) {
+            System.out.println("External resource external.txt was not found on the classpath!");
+            return;
+        }
+        System.out.println("External: " + new BufferedReader(new InputStreamReader(ext)).readLine());
     }
 }

--- a/tests/suite/jdk_release_test.rs
+++ b/tests/suite/jdk_release_test.rs
@@ -1,0 +1,85 @@
+use assert_cmd::Command;
+use std::path::Path;
+
+fn fixture_path() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("jdk-version")
+}
+
+fn copy_fixture() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    let dest = tmp.path().join("project");
+    fs_extra::dir::copy(
+        fixture_path(),
+        &dest,
+        &fs_extra::dir::CopyOptions::new().content_only(true),
+    )
+    .unwrap();
+    tmp
+}
+
+#[test]
+fn release_version_flows_to_settings_classpath_and_metadata() -> Result<(), Box<dyn std::error::Error>>
+{
+    let tmp = copy_fixture();
+    let dest = tmp.path().join("project");
+
+    let mut cmd = Command::cargo_bin("lazy-java")?;
+    cmd.current_dir(&dest);
+    cmd.args(["sync"]);
+    cmd.assert().success();
+
+    let settings = std::fs::read_to_string(dest.join(".settings/org.eclipse.core.prefs"))?;
+    assert!(
+        settings.contains("org.eclipse.jdt.core.compiler.source=11"),
+        "settings should pin source to the configured release: {settings}"
+    );
+    assert!(
+        settings.contains("org.eclipse.jdt.core.compiler.compliance=11"),
+        "settings should pin compliance to the configured release: {settings}"
+    );
+    assert!(
+        settings.contains("org.eclipse.jdt.core.compiler.codegen.targetPlatform=11"),
+        "settings should pin targetPlatform to the configured release: {settings}"
+    );
+
+    let classpath = std::fs::read_to_string(dest.join(".classpath"))?;
+    assert!(
+        classpath.contains("JavaSE-11"),
+        "classpath should reference the configured JRE version: {classpath}"
+    );
+
+    let mut cmd = Command::cargo_bin("lazy-java")?;
+    cmd.current_dir(&dest);
+    cmd.args(["build"]);
+    cmd.assert().success();
+
+    let metadata = std::fs::read_to_string(dest.join("target/.lazy-java-build"))?;
+    assert!(
+        metadata.contains("java_version = \"11\""),
+        "metadata should record the config release: {metadata}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn cli_release_overrides_config_in_metadata() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = copy_fixture();
+    let dest = tmp.path().join("project");
+
+    let mut cmd = Command::cargo_bin("lazy-java")?;
+    cmd.current_dir(&dest);
+    cmd.args(["build", "--release", "17"]);
+    cmd.assert().success();
+
+    let metadata = std::fs::read_to_string(dest.join("target/.lazy-java-build"))?;
+    assert!(
+        metadata.contains("java_version = \"17\""),
+        "CLI --release should override the config release: {metadata}"
+    );
+
+    Ok(())
+}

--- a/tests/suite/jdk_release_test.rs
+++ b/tests/suite/jdk_release_test.rs
@@ -21,8 +21,8 @@ fn copy_fixture() -> tempfile::TempDir {
 }
 
 #[test]
-fn release_version_flows_to_settings_classpath_and_metadata() -> Result<(), Box<dyn std::error::Error>>
-{
+fn release_version_flows_to_settings_classpath_and_metadata()
+-> Result<(), Box<dyn std::error::Error>> {
     let tmp = copy_fixture();
     let dest = tmp.path().join("project");
 

--- a/tests/suite/mod.rs
+++ b/tests/suite/mod.rs
@@ -9,6 +9,7 @@ mod generate_pom_test;
 mod group44_test;
 mod import_pom_test;
 mod incremental_build_test;
+mod jdk_release_test;
 mod remove_dependency_test;
 mod resources_copy_test;
 mod sync_build_run_test;

--- a/tests/suite/resources_copy_test.rs
+++ b/tests/suite/resources_copy_test.rs
@@ -35,7 +35,10 @@ fn build_copies_resources_to_bin_and_run_reads_them() -> Result<(), Box<dyn std:
         "secret.txt should be excluded from bin resources"
     );
     assert!(
-        dest.join("target").join("bin").join("external.txt").exists(),
+        dest.join("target")
+            .join("bin")
+            .join("external.txt")
+            .exists(),
         "external.txt should be copied to bin as an external resource"
     );
 

--- a/tests/suite/resources_copy_test.rs
+++ b/tests/suite/resources_copy_test.rs
@@ -34,8 +34,12 @@ fn build_copies_resources_to_bin_and_run_reads_them() -> Result<(), Box<dyn std:
         !dest.join("target").join("bin").join("secret.txt").exists(),
         "secret.txt should be excluded from bin resources"
     );
+    assert!(
+        dest.join("target").join("bin").join("external.txt").exists(),
+        "external.txt should be copied to bin as an external resource"
+    );
 
-    // Run reads the resource from the classpath
+    // Run reads the resources from the classpath
     let mut cmd = Command::cargo_bin("lazy-java")?;
     cmd.current_dir(&dest);
     cmd.args(["run", "Main"]);
@@ -43,6 +47,9 @@ fn build_copies_resources_to_bin_and_run_reads_them() -> Result<(), Box<dyn std:
         .success()
         .stdout(predicate::str::contains(
             "Resource content: Hello from resource file!",
+        ))
+        .stdout(predicate::str::contains(
+            "External: External resource content",
         ));
 
     Ok(())

--- a/tests/suite/snapshots/all__suite__generate_pom_test__generate_pom_output.snap
+++ b/tests/suite/snapshots/all__suite__generate_pom_test__generate_pom_output.snap
@@ -34,6 +34,11 @@ expression: pom_content
             <type>jar</type>
         </dependency>
     </dependencies>
+    <properties>
+        <map>
+            <maven.compiler.release>25</maven.compiler.release>
+        </map>
+    </properties>
     <build>
         <plugins>
             <plugin>

--- a/tests/suite/snapshots/all__suite__import_pom_test__import_pom_output.snap
+++ b/tests/suite/snapshots/all__suite__import_pom_test__import_pom_output.snap
@@ -1,13 +1,20 @@
 ---
 source: tests/suite/import_pom_test.rs
+assertion_line: 32
 expression: toml_content
 ---
+[dependancies]
+commons-lang3 = { group = "org.apache.commons", version = "3.12.0", scope = "compile" }
+guava = { group = "com.google.guava", version = "33.0.0-jre", scope = "compile" }
+
 [project]
 name = "my-library"
 group = "com.example"
 artifact = "my-library"
 version = "1.2.3"
 
-[dependancies]
-commons-lang3 = { group = "org.apache.commons", version = "3.12.0" }
-guava = { group = "com.google.guava", version = "33.0.0-jre" }
+[setup]
+src = "src/main/java"
+
+[resources]
+external = ["src/main/resources/**"]

--- a/tests/suite/snapshots/all__suite__remove_dependency_test__add_dependency_lock.snap
+++ b/tests/suite/snapshots/all__suite__remove_dependency_test__add_dependency_lock.snap
@@ -109,11 +109,20 @@ artifact = "log4j-api"
 version = "2.25.4"
 file_name = "log4j-api-2.25.4.jar"
 url = "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.25.4/log4j-api-2.25.4.jar"
-dependancies = []
 packaging = "jar"
 root = false
 scope = "compile"
 annotations = []
+
+[[package.dependancies]]
+group = "org.jspecify"
+artifact = "jspecify"
+version = "1.0.0"
+
+[[package.dependancies]]
+group = "org.osgi"
+artifact = "org.osgi.core"
+version = "6.0.0"
 
 [[package]]
 group = "org.apache.logging.log4j"
@@ -131,12 +140,34 @@ group = "org.apache.logging.log4j"
 artifact = "log4j-api"
 version = "2.25.4"
 
+[[package.dependancies]]
+group = "org.jspecify"
+artifact = "jspecify"
+version = "1.0.0"
+
+[[package.dependancies]]
+group = "org.osgi"
+artifact = "org.osgi.core"
+version = "6.0.0"
+
 [[package]]
 group = "org.jspecify"
 artifact = "jspecify"
 version = "1.0.0"
 file_name = "jspecify-1.0.0.jar"
 url = "https://repo1.maven.org/maven2/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar"
+dependancies = []
+packaging = "jar"
+root = false
+scope = "compile"
+annotations = []
+
+[[package]]
+group = "org.osgi"
+artifact = "org.osgi.core"
+version = "6.0.0"
+file_name = "org.osgi.core-6.0.0.jar"
+url = "https://repo1.maven.org/maven2/org/osgi/org.osgi.core/6.0.0/org.osgi.core-6.0.0.jar"
 dependancies = []
 packaging = "jar"
 root = false


### PR DESCRIPTION
## Summary

A set of build/import improvements around dependency handling, JDK version management, resource copying, and POM import. Contains several related but distinct features.

## Features

### 1. Configurable JDK version (source/target/release)
- New CLI flag `--release <version>` on build commands.
- New `[setup] release` TOML config field.
- Version resolution order: `--release` CLI flag > `[setup] release` config > installed JDK major > default `"25"` (with a yellow warning when it falls back).
- `javac` now compiles with `--release <version>`.
- The resolved version flows into:
  - Eclipse-style `.settings` prefs (source/compliance/targetPlatform)
  - `.classpath` JRE container as `JavaSE-{version}`
  - Generated `pom.xml` as the `maven.compiler.release` property
  - Build metadata (`java_version`)
- Changing the release version triggers a full rebuild (new `required_full_build` helper in `metadata.rs`).
- New `src/utils/jdk_version.rs` with `desired_jdk_version` (cached), `installed_jdk_version`, `parse_major`, and a `warn_runtime_mismatch` helper.
- Runtime `run` path warns (yellow) when the running JDK differs from the version the classes were compiled with, by reading the recorded `BuildMetadata.java_version`.

### 2. JDK tool resolution + improved error reporting
- New `java_tool_command(tool)` in `processes.rs`: prefers `$JAVA_HOME/bin/<tool>` (with `.exe` support on Windows), falls back to system PATH.
- New `BuildError` variants `JavacNotFound`, `JarNotFound`, `JavaNotFound`, with clear messages when a JDK tool is missing.

### 3. Maven dependency scopes
- Scopes (`compile`, `runtime`, `provided`, etc.) parsed from POMs and imported into `lazy-java.toml` (`dependancy` entries gain a `scope` field).
- `add` command gained `--scope`; unparseable scope values warn in yellow.
- `MavenDependancyList::new` now accepts an `Option<Scope>` and filters appropriately.

### 4. `[resources] external`
- New config field `[resources] external = ["glob", ...]` lets a project treat config/dependency-style files outside `src` as resources copied into `target/bin`.
- Skip logic for hidden files and `src`/`target`/`bin`.
- Guard fix for `is_same_file` in resource comparison.

### 5. `import pom` improvements
- Adds the `--only-dependencies` flag: when set, only dependencies are imported and project/setup settings are left untouched.
- When a dependency declares no version and isn't in `dependencyManagement`, resolve the latest version from Maven Central metadata (fallback: skip with a yellow warning).
- Imports dependency `scope`.
- When importing project metadata, maps common Maven conventions:
  - `java.version` property → `[setup] release`
  - `src/main/java` → `[setup] src`
  - `src/main/resources/**` → `[resources] external`

## Build/Metadata
- `BuildMetadata` now records the `src` directory; `required_full_build` triggers a full rebuild when `[setup] src` or `--source` changes (compared via `is_same_file`) — previously changing the source dir did NOT recompile.

## Tests
- `tests/suite/jdk_release_test.rs`: release version flows to settings/classpath/metadata, CLI override.
- `tests/suite/resources_copy_test.rs`: external resource copy + runtime read.
- Updated snapshots: `import_pom_output`, `generate_pom_output`, `add_dependency_lock`.
- 8 `MavenDependancyList::new` call sites updated for the new `Optional<Scope>` parameter.
- `parse_major` unit tests in `jdk_version.rs`.

## Notes
- `run jar` does not emit the runtime-mismatch warning (a JAR's compile version isn't discoverable at runtime).
- Follow-ups tracked separately: #70 (JUnit/test support), #71 (local JAR/dependency sources), #72 (README/docs).