### PR TITLE
Support external/local jar dependencies

### DIFF
--- a/src/build/build_java.rs
+++ b/src/build/build_java.rs
@@ -57,7 +57,7 @@ impl LazyJava {
         let glob = build_globset(ctx);
 
         let files: Result<Vec<PathBuf>, BuildError> =
-            if required_full_build(args, ctx, build_data.as_ref()) {
+            if required_full_build(args, ctx, build_data.as_ref())? {
                 let files = find_java_files_glob(&ctx.src, &glob);
                 println!(
                     "{} using full build ({} file{})",

--- a/src/build/compile.rs
+++ b/src/build/compile.rs
@@ -9,42 +9,48 @@ use log::warn;
 use crate::{
     Context, JAVAC_SEPERATOR,
     build::BuildError,
-    utils::{IOError, join_directory, processes::java_tool_command},
+    utils::{IOError, SeperatorList, join_directory, processes::java_tool_command},
 };
 
-/// Anything postfixed with list should be a : or ; seperated list depending on platform, expect
-/// src_list that is a space seperated list
+/// Build and run a `javac` command. Each `Option<&str>` maps to a javac flag
+/// that is emitted only when present:
+///
+///   - `output_dir`         -> `-d <dir>`
+///   - `classpath`          -> `-classpath <cp>`
+///   - `processorpath`      -> `-processorpath <pp>`
+///   - `src_generated_dir`  -> `-s <dir>`
+///   - `release`            -> `--release <version>`
+///
+/// `javac_args` are forwarded verbatim and `source_files` are added as
+/// positional arguments.
 pub(crate) fn compile_command(
-    src_list: &str,
-    output_dir: &str,
-    bin_dir: &str,
-    lib_dir: &str,
-    annotation_lib_list: &str,
-    annotation_lib: &str,
-    src_generated_dir: &str,
-    build_processor_dir: &str,
-    javac_args: &Vec<String>,
+    output_dir: Option<&str>,
+    classpath: Option<&str>,
+    processorpath: Option<&str>,
+    src_generated_dir: Option<&str>,
     release: Option<&str>,
+    javac_args: &[String],
+    source_files: &[String],
 ) -> Result<Output, io::Error> {
-    let sep = JAVAC_SEPERATOR;
-    let classpath =
-        format!("{build_processor_dir}{sep}{bin_dir}{sep}{annotation_lib}/*{sep}{lib_dir}/*");
-    let processorpath = format!("{annotation_lib_list}{sep}{build_processor_dir}");
-
     let mut cmd = java_tool_command("javac");
-    cmd.arg("-s")
-        .arg(src_generated_dir)
-        .arg("-processorpath")
-        .arg(&processorpath)
-        .arg("-classpath")
-        .arg(&classpath)
-        .arg("-d")
-        .arg(output_dir);
+
+    if let Some(dir) = output_dir {
+        cmd.arg("-d").arg(dir);
+    }
+    if let Some(cp) = classpath {
+        cmd.arg("-classpath").arg(cp);
+    }
+    if let Some(pp) = processorpath {
+        cmd.arg("-processorpath").arg(pp);
+    }
+    if let Some(gen_dir) = src_generated_dir {
+        cmd.arg("-s").arg(gen_dir);
+    }
     if let Some(version) = release {
         cmd.arg("--release").arg(version);
     }
     cmd.args(javac_args);
-    for src in src_list.split_whitespace() {
+    for src in source_files {
         cmd.arg(src);
     }
 
@@ -94,26 +100,46 @@ pub fn compile_java(
     let ab_src_generated = resolve("resolving generated source directory", &ctx.src_generated)?;
     let src_generated_destructured = join_directory(&ab_src_generated, ' ');
     let ab_bin_processor = resolve("resolving processor bin directory", &ctx.bin_processors)?;
-    log::debug!("Processor build output directory: {:?}", ab_bin_processor);
-    log::debug!("Annotation library path: {:?}", ab_annotation_lib_list);
 
-    let mut src_des = string_list.join(" ");
+    let local_deps: Vec<_> = ctx
+        .config
+        .local_package_list()?
+        .into_iter()
+        .map(|dep| dep.path.to_string_lossy().to_string())
+        .collect();
+
+    let sep = JAVAC_SEPERATOR;
+    let classpath = SeperatorList::new(sep)
+        .add(ab_bin_processor.display())
+        .add(ab_bin.display())
+        .add_glob(ab_annotation_lib.display())
+        .add_glob(ab_lib.display())
+        .add_slice(&local_deps)
+        .build();
+
+    let processorpath = SeperatorList::new(sep)
+        .add(ab_annotation_lib_list)
+        .add(ab_bin_processor.display())
+        .add_slice(&local_deps)
+        .build();
+
+    let mut source_files = string_list;
     if compile_generated_source {
-        src_des.push(' ');
-        src_des.push_str(&src_generated_destructured);
+        source_files.extend(
+            src_generated_destructured
+                .split_whitespace()
+                .map(|s| s.to_string()),
+        );
     }
 
     let output = match compile_command(
-        &src_des,
-        ab_dest.to_str().unwrap(),
-        ab_bin.to_str().unwrap(),
-        ab_lib.to_str().unwrap(),
-        &ab_annotation_lib_list,
-        ab_annotation_lib.to_str().unwrap(),
-        ab_src_generated.to_str().unwrap(),
-        ab_bin_processor.to_str().unwrap(),
-        javac_args,
+        Some(ab_dest.to_str().unwrap()),
+        Some(&classpath),
+        Some(&processorpath),
+        Some(ab_src_generated.to_str().unwrap()),
         release,
+        javac_args,
+        &source_files,
     ) {
         Ok(output) => output,
         Err(e) if e.kind() == io::ErrorKind::NotFound => return Err(BuildError::JavacNotFound),

--- a/src/build/compile_tests.rs
+++ b/src/build/compile_tests.rs
@@ -36,17 +36,29 @@ fn test_compile_command_simple() -> Result<(), std::io::Error> {
 
     let java_file = test_java_file(&src_dir);
 
+    let sep = crate::JAVAC_SEPERATOR;
+    let classpath = format!(
+        "{}{sep}{}{sep}{}/*{sep}{}/*",
+        processor_dir.display(),
+        build_dir.display(),
+        annotation_lib_dir.display(),
+        lib_dir.display()
+    );
+    let processorpath = format!(
+        "{}{sep}{}",
+        annotation_lib_dir.display(),
+        processor_dir.display()
+    );
+    let source_files = vec![java_file.to_string_lossy().to_string()];
+
     let result = compile_command(
-        &java_file.to_string_lossy(),
-        &build_dir.to_string_lossy(),
-        &build_dir.to_string_lossy(),
-        &lib_dir.to_string_lossy(),
-        &annotation_lib_dir.to_string_lossy(),
-        &annotation_lib_dir.to_string_lossy(),
-        &src_generated_dir.to_string_lossy(),
-        &processor_dir.to_string_lossy(),
-        &Vec::new(),
+        Some(&build_dir.to_string_lossy()),
+        Some(&classpath),
+        Some(&processorpath),
+        Some(&src_generated_dir.to_string_lossy()),
         None,
+        &Vec::new(),
+        &source_files,
     )?;
 
     assert!(
@@ -91,17 +103,29 @@ public class Greeting {{
     )
     .unwrap();
 
+    let sep = crate::JAVAC_SEPERATOR;
+    let classpath = format!(
+        "{}{sep}{}{sep}{}/*{sep}{}/*",
+        processor_dir.display(),
+        build_dir.display(),
+        annotation_lib_dir.display(),
+        lib_dir.display()
+    );
+    let processorpath = format!(
+        "{}{sep}{}",
+        annotation_lib_dir.display(),
+        processor_dir.display()
+    );
+    let source_files = vec![file_path.to_string_lossy().to_string()];
+
     let result = compile_command(
-        &file_path.to_string_lossy(),
-        &build_dir.to_string_lossy(),
-        &build_dir.to_string_lossy(),
-        &lib_dir.to_string_lossy(),
-        &annotation_lib_dir.to_string_lossy(),
-        &annotation_lib_dir.to_string_lossy(),
-        &src_generated_dir.to_string_lossy(),
-        &processor_dir.to_string_lossy(),
-        &Vec::new(),
+        Some(&build_dir.to_string_lossy()),
+        Some(&classpath),
+        Some(&processorpath),
+        Some(&src_generated_dir.to_string_lossy()),
         None,
+        &Vec::new(),
+        &source_files,
     )?;
 
     assert!(

--- a/src/build/metadata.rs
+++ b/src/build/metadata.rs
@@ -22,7 +22,9 @@ pub struct BuildMetadata {
     pub java_version: String,
     pub src: PathBuf,
     pub lib_hash: u64,
+    pub lib_annotations_hash: u64,
     pub bin_hash: u64,
+    pub local_libs_hash: u64,
     pub build_passed: bool,
 }
 
@@ -33,7 +35,9 @@ impl BuildMetadata {
             java_version: "".into(),
             src: "".into(),
             lib_hash: 0,
+            lib_annotations_hash: 0,
             bin_hash: 0,
+            local_libs_hash: 0,
             build_passed: false,
         }
     }
@@ -61,20 +65,36 @@ impl Default for BuildMetadata {
         Self::new()
     }
 }
-pub fn required_full_build(args: &BuildArgs, ctx: &Context, meta: Option<&BuildMetadata>) -> bool {
+pub fn required_full_build(
+    args: &BuildArgs,
+    ctx: &Context,
+    meta: Option<&BuildMetadata>,
+) -> Result<bool, BuildError> {
     let Some(meta) = meta else {
-        return true;
+        return Ok(true);
     };
 
     let current_lib_hash = hash_directory(&ctx.lib);
     let lib_hash_match = current_lib_hash == meta.lib_hash;
+
+    let current_lib_annotations_hash = hash_directory(&ctx.lib_annotations);
+    let lib_annotations_hash_match =
+        current_lib_annotations_hash == meta.lib_annotations_hash;
+
+    let current_local_hash = hash_local_libs(ctx)?;
+    let local_hash_match = current_local_hash == meta.local_libs_hash;
 
     let jdk = desired_jdk_version(Some(args), Some(ctx));
     let version_match = meta.java_version == jdk;
 
     let src_match = is_same_file(&meta.src, &ctx.src).unwrap_or(false);
 
-    args.build_all || !lib_hash_match || !version_match || !src_match
+    Ok(args.build_all
+        || !lib_hash_match
+        || !lib_annotations_hash_match
+        || !version_match
+        || !src_match
+        || !local_hash_match)
 }
 
 pub fn save_metadata(
@@ -95,7 +115,9 @@ pub fn save_metadata(
         time_stamp: time,
         java_version: jdk.to_string(),
         lib_hash: hash_directory(&ctx.lib),
+        lib_annotations_hash: hash_directory(&ctx.lib_annotations),
         bin_hash: hash_directory(&ctx.bin),
+        local_libs_hash: hash_local_libs(ctx)?,
         build_passed: status.success(),
         src: ctx.src.clone(),
     };
@@ -126,4 +148,27 @@ pub fn hash_directory(path: &Path) -> u64 {
     let hash = hasher.finish();
     log::debug!("hash_directory({:?}) = {}", path, hash);
     hash
+}
+
+/// Hash the local dependency jars referenced by the project's config so a full
+/// rebuild is triggered whenever one of them changes.
+pub fn hash_local_libs(ctx: &Context) -> Result<u64, BuildError> {
+    let deps = ctx.config.local_package_list()?;
+    let paths: Vec<PathBuf> = deps.into_iter().map(|dep| dep.path).collect();
+
+    let hash = hash_files(&paths);
+    log::debug!("hash_local_libs = {}", hash);
+    Ok(hash)
+}
+
+/// Hash a set of files by their paths and byte contents.
+pub fn hash_files(paths: &[PathBuf]) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    for path in paths {
+        path.hash(&mut hasher);
+        if let Ok(bytes) = fs::read(path) {
+            bytes.hash(&mut hasher);
+        }
+    }
+    hasher.finish()
 }

--- a/src/build/metadata_tests.rs
+++ b/src/build/metadata_tests.rs
@@ -12,6 +12,7 @@ mod tests {
         assert_eq!(meta.java_version, "");
         assert_eq!(meta.lib_hash, 0);
         assert_eq!(meta.bin_hash, 0);
+        assert_eq!(meta.local_libs_hash, 0);
         assert!(!meta.build_passed);
     }
 
@@ -29,7 +30,9 @@ mod tests {
             java_version: "21".into(),
             src: "src".into(),
             lib_hash: 42,
+            lib_annotations_hash: 7,
             bin_hash: 123,
+            local_libs_hash: 99,
             build_passed: true,
         };
 
@@ -38,7 +41,9 @@ mod tests {
 
         assert_eq!(fetched.java_version, "21");
         assert_eq!(fetched.lib_hash, 42);
+        assert_eq!(fetched.lib_annotations_hash, 7);
         assert_eq!(fetched.bin_hash, 123);
+        assert_eq!(fetched.local_libs_hash, 99);
         assert!(fetched.build_passed);
     }
 
@@ -76,6 +81,58 @@ mod tests {
 
         fs::remove_file(dir.path().join("b.txt")).unwrap();
         let after = crate::build::metadata::hash_directory(dir.path());
+
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn hash_files_changes_when_content_changes() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("lib.jar");
+        fs::write(&file, b"AAAA").unwrap();
+        let before = crate::build::metadata::hash_files(&[file.clone()]);
+
+        fs::write(&file, b"BBBB").unwrap();
+        let after = crate::build::metadata::hash_files(&[file.clone()]);
+
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn hash_files_is_deterministic() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("lib.jar");
+        fs::write(&file, b"hello-world").unwrap();
+
+        let hash1 = crate::build::metadata::hash_files(&[file.clone()]);
+        let hash2 = crate::build::metadata::hash_files(&[file.clone()]);
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn hash_files_changes_when_file_added() {
+        let dir = tempdir().unwrap();
+        let a = dir.path().join("a.jar");
+        fs::write(&a, b"A").unwrap();
+        let before = crate::build::metadata::hash_files(&[a.clone()]);
+
+        let b = dir.path().join("b.jar");
+        fs::write(&b, b"B").unwrap();
+        let after = crate::build::metadata::hash_files(&[a.clone(), b.clone()]);
+
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn hash_files_changes_when_file_removed() {
+        let dir = tempdir().unwrap();
+        let a = dir.path().join("a.jar");
+        fs::write(&a, b"A").unwrap();
+        let b = dir.path().join("b.jar");
+        fs::write(&b, b"B").unwrap();
+
+        let before = crate::build::metadata::hash_files(&[a.clone(), b.clone()]);
+        let after = crate::build::metadata::hash_files(&[a.clone()]);
 
         assert_ne!(before, after);
     }

--- a/src/build/resources.rs
+++ b/src/build/resources.rs
@@ -31,11 +31,12 @@ pub fn copy_resources(ctx: &Context) -> Result<(), BuildError> {
     } else {
         Vec::new()
     };
-    let glob_external = build_globset(&external);
 
-    let external_paths = add_external_resources(&ctx.root, &glob_external, ctx)?;
-
-    resource_paths.extend(external_paths);
+    if !external.is_empty() {
+        let glob_external = build_globset(&external);
+        let external_paths = add_external_resources(&ctx.root, &glob_external, ctx)?;
+        resource_paths.extend(external_paths);
+    }
 
     let removed = remove_unknown_resources(&resource_paths, &ctx.bin, ctx)?;
     log::info!("Removed {} resources", removed);

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -6,8 +6,8 @@ use log::debug;
 use crate::{
     CONFIG_FILE_NAME, ContextNoConfig,
     args::{AddArgs, RemoveArgs},
-    config::{ConfigDependancy, ConfigTomlEdit, config_error::ConfigError},
-    lock_file::LockFile,
+    config::{ConfigTomlEdit, LocalDependency, RemoteDependency, config_error::ConfigError},
+    lock_file::{LockFile, RootPackage},
     maven_central::{
         MavenError, MavenIdBuf, PartialMavenIdBuf, fetch_artifact_metadata, pom::Scope,
     },
@@ -128,7 +128,7 @@ impl ConfigTomlEdit {
         lockfile: &mut LockFile,
         ctx: &ContextNoConfig,
     ) -> Result<(), ConfigError> {
-        let dep_list = self.dependancy_list()?;
+        let dep_list = self.root_package_list()?;
         lockfile.sync_with_root_packages(&dep_list)?;
 
         lockfile.validate_current_packages(ctx)?;
@@ -136,23 +136,38 @@ impl ConfigTomlEdit {
         lockfile.write(&ctx.root)?;
         Ok(())
     }
-    pub fn dependancy_list(
+    pub fn root_package_list(
         &self,
-    ) -> Result<HashMap<PartialMavenIdBuf, ConfigDependancy>, ConfigError> {
+    ) -> Result<HashMap<PartialMavenIdBuf, RootPackage>, ConfigError> {
         if let Some(deps) = self.dependancies() {
             let mut map = HashMap::new();
             for (k, dep) in deps {
-                let de: Result<ConfigDependancy, ConfigError> = dep.to_config_dependancy();
-                let de = de?;
+                let de: Option<RemoteDependency> = dep.to_remote_dependency()?;
 
-                let id = PartialMavenIdBuf::new(&de.group, k);
+                if let Some(dep) = de {
+                    let id = PartialMavenIdBuf::new(&dep.group, k);
 
-                map.insert(id, de);
+                    map.insert(id, dep.into());
+                }
             }
 
             Ok(map)
         } else {
             Ok(HashMap::new())
+        }
+    }
+    pub fn local_package_list(&self) -> Result<Vec<LocalDependency>, ConfigError> {
+        if let Some(deps) = self.dependancies() {
+            let mut v = Vec::new();
+            for (_key, dep) in deps {
+                let de: Option<LocalDependency> = dep.to_local_dependency()?;
+                if let Some(dep) = de {
+                    v.push(dep);
+                }
+            }
+            Ok(v)
+        } else {
+            Ok(Vec::new())
         }
     }
 

--- a/src/config/config_error.rs
+++ b/src/config/config_error.rs
@@ -36,16 +36,16 @@ pub enum ConfigError {
     UnexpectedValue(&'static str),
 
     #[error("Local dependency path does not exist")]
-    LocalDependnecyNotFound(PathBuf),
+    LocalDependencyNotFound(PathBuf),
 
     #[error("Local dependency is not a jar file")]
-    LocalDependnecyNotJar(PathBuf),
+    LocalDependencyNotJar(PathBuf),
 }
 
 impl DiagnosticProvider for ConfigError {
     fn diagnostic(&self) -> Diagnostic {
         match self {
-            ConfigError::LocalDependnecyNotFound(path) => {
+            ConfigError::LocalDependencyNotFound(path) => {
                 Diagnostic::new("Local dependency path does not exist")
                     .message(format!(
                         "Could not find the local dependency {}",
@@ -53,7 +53,7 @@ impl DiagnosticProvider for ConfigError {
                     ))
                     .help("Ensure that the path given exists and is a jar file")
             }
-            ConfigError::LocalDependnecyNotJar(path) => {
+            ConfigError::LocalDependencyNotJar(path) => {
                 Diagnostic::new("Local dependency is not a jar file")
                     .message(format!(
                         "The local dependency {} does not have a .jar extension",

--- a/src/config/config_error.rs
+++ b/src/config/config_error.rs
@@ -31,15 +31,48 @@ pub enum ConfigError {
 
     #[error("Could not remove because package is not included in config file")]
     PackageNotFound,
+
+    #[error("Could not parse ConfigDependancy unexpected field '{0}'")]
+    UnexpectedValue(&'static str),
+
+    #[error("Local dependency path does not exist")]
+    LocalDependnecyNotFound(PathBuf),
+
+    #[error("Local dependency is not a jar file")]
+    LocalDependnecyNotJar(PathBuf),
 }
 
 impl DiagnosticProvider for ConfigError {
     fn diagnostic(&self) -> Diagnostic {
         match self {
+            ConfigError::LocalDependnecyNotFound(path) => {
+                Diagnostic::new("Local dependency path does not exist")
+                    .message(format!(
+                        "Could not find the local dependency {}",
+                        path.display()
+                    ))
+                    .help("Ensure that the path given exists and is a jar file")
+            }
+            ConfigError::LocalDependnecyNotJar(path) => {
+                Diagnostic::new("Local dependency is not a jar file")
+                    .message(format!(
+                        "The local dependency {} does not have a .jar extension",
+                        path.display()
+                    ))
+                    .note("Currently only .jar files are supported as local dependencies")
+                    .help("Point the dependency at a valid .jar file")
+            }
+
             ConfigError::MissingValue(field) => Diagnostic::new("Missing lazy-java.toml value")
                 .message(format!(
                     "Could not parse lazy-java.toml, missing field '{field}'."
                 )),
+            ConfigError::UnexpectedValue(field) => {
+                Diagnostic::new("Unexpected value in lazy-java.toml ").message(format!(
+                    "Could not parse lazy-java.toml, unexpected field '{field}'."
+                ))
+            }
+
             ConfigError::ParseError(err) => {
                 Diagnostic::new("Failed to parse lazy-java.toml").note(err.to_string())
             }

--- a/src/config/config_structs.rs
+++ b/src/config/config_structs.rs
@@ -111,10 +111,6 @@ pub struct RemoteDependency {
 pub struct LocalDependency {
     pub path: PathBuf,
 }
-pub enum ConfigDependancyParsed {
-    Remote(RemoteDependency),
-    Local(LocalDependency),
-}
 
 impl<'a> ConfigDependancyTomlEditView<'a> {
     pub fn to_remote_dependency(&self) -> Result<Option<RemoteDependency>, ConfigError> {
@@ -155,10 +151,10 @@ impl<'a> ConfigDependancyTomlEditView<'a> {
         let path = PathBuf::from(&path);
 
         if !path.exists() {
-            return Err(ConfigError::LocalDependnecyNotFound(path));
+            return Err(ConfigError::LocalDependencyNotFound(path));
         }
         if path.extension() != Some(OsStr::new("jar")) {
-            return Err(ConfigError::LocalDependnecyNotJar(path));
+            return Err(ConfigError::LocalDependencyNotJar(path));
         }
 
         let con = canonicalize(&path)

--- a/src/config/config_structs.rs
+++ b/src/config/config_structs.rs
@@ -1,5 +1,10 @@
-use crate::{config::ConfigError, maven_central::pom::Scope};
-use std::{collections::HashMap, path::PathBuf};
+use crate::{
+    config::ConfigError,
+    lock_file::RootPackage,
+    maven_central::pom::Scope,
+    utils::{IOError, fs::canonicalize},
+};
+use std::{collections::HashMap, ffi::OsStr, path::PathBuf};
 
 use serde::{Deserialize, Serialize};
 use toml_edit_derive::TomlEdit;
@@ -54,13 +59,6 @@ impl<'a> ConfigProcesserDefinitionTomlEditView<'a> {
         })
     }
 }
-fn assert<T>(value: Option<T>, name: &'static str) -> Result<T, ConfigError> {
-    if let Some(v) = value {
-        Ok(v)
-    } else {
-        Err(ConfigError::MissingValue(name))
-    }
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, TomlEdit)]
 #[serde(deny_unknown_fields)]
@@ -102,19 +100,80 @@ pub struct ConfigSetup {
 pub struct ConfigDependancy {
     pub group: String,
     pub version: String,
+    pub scope: Scope,
+    pub path: String,
+}
+pub struct RemoteDependency {
+    pub group: String,
+    pub version: String,
     pub scope: Option<Scope>,
+}
+pub struct LocalDependency {
+    pub path: PathBuf,
+}
+pub enum ConfigDependancyParsed {
+    Remote(RemoteDependency),
+    Local(LocalDependency),
 }
 
 impl<'a> ConfigDependancyTomlEditView<'a> {
-    pub fn to_config_dependancy(&self) -> Result<ConfigDependancy, ConfigError> {
-        let group = assert(self.group(), "group_id")?;
-        let version = assert(self.version(), "version")?;
+    pub fn to_remote_dependency(&self) -> Result<Option<RemoteDependency>, ConfigError> {
+        let group = self.group();
+        let version = self.version();
         let scope = self.scope();
-        Ok(ConfigDependancy {
+        let path = self.path();
+
+        if group.is_none() && version.is_none() {
+            return Ok(None);
+        }
+        assert_none(path, "path")?;
+
+        let group = assert(group, "group")?;
+        let version = assert(version, "version")?;
+
+        Ok(Some(RemoteDependency {
             group,
             version,
             scope,
-        })
+        }))
+    }
+    pub fn to_local_dependency(&self) -> Result<Option<LocalDependency>, ConfigError> {
+        let group = self.group();
+        let version = self.version();
+        let scope = self.scope();
+        let path = self.path();
+
+        if path.is_none() {
+            return Ok(None);
+        }
+        assert_none(group, "group")?;
+        assert_none(version, "version")?;
+        assert_none(scope, "scope")?;
+
+        let path = assert(path, "path")?;
+
+        let path = PathBuf::from(&path);
+
+        if !path.exists() {
+            return Err(ConfigError::LocalDependnecyNotFound(path));
+        }
+        if path.extension() != Some(OsStr::new("jar")) {
+            return Err(ConfigError::LocalDependnecyNotJar(path));
+        }
+
+        let con = canonicalize(&path)
+            .map_err(|e| IOError::new("resolving local dependency path", path, e))?;
+
+        Ok(Some(LocalDependency { path: con }))
+    }
+}
+impl Into<RootPackage> for RemoteDependency {
+    fn into(self) -> RootPackage {
+        RootPackage {
+            scope: self.scope,
+            group: self.group,
+            version: self.version,
+        }
     }
 }
 
@@ -132,4 +191,20 @@ pub struct ConfigResources {
 
 fn is_default<T: Default + PartialEq>(value: &T) -> bool {
     value == &T::default()
+}
+
+fn assert<T>(value: Option<T>, name: &'static str) -> Result<T, ConfigError> {
+    if let Some(v) = value {
+        Ok(v)
+    } else {
+        Err(ConfigError::MissingValue(name))
+    }
+}
+
+fn assert_none<T>(value: Option<T>, name: &'static str) -> Result<(), ConfigError> {
+    if let Some(_v) = value {
+        Err(ConfigError::UnexpectedValue(name))
+    } else {
+        Ok(())
+    }
 }

--- a/src/lock_file/lock_file.rs
+++ b/src/lock_file/lock_file.rs
@@ -12,7 +12,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     ContextNoConfig, LOCK_FILE_NAME,
-    config::ConfigDependancy,
     lock_file::LockFileError,
     maven_central::{
         MavenId, MavenIdBuf, PartialMavenIdBuf,
@@ -45,6 +44,13 @@ pub struct LockFilePackage {
 
     #[serde(default)]
     pub annotations: Vec<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
+pub struct RootPackage {
+    pub scope: Option<Scope>,
+    pub group: String,
+    pub version: String,
 }
 
 impl LockFile {
@@ -225,7 +231,7 @@ impl LockFile {
     }
     pub fn sync_with_root_packages(
         &mut self,
-        root_packages: &HashMap<PartialMavenIdBuf, ConfigDependancy>,
+        root_packages: &HashMap<PartialMavenIdBuf, RootPackage>,
     ) -> Result<(), LockFileError> {
         let mut map: HashSet<PartialMavenIdBuf> = self
             .packages

--- a/src/run/execute.rs
+++ b/src/run/execute.rs
@@ -1,0 +1,120 @@
+use std::{
+    io, path,
+    process::{ExitStatus, Output, Stdio},
+};
+
+use crate::{
+    Context, JAVAC_SEPERATOR,
+    args::RunArgs,
+    build::BuildError,
+    utils::{IOError, SeperatorList, processes::java_tool_command},
+};
+
+/// Build and run a raw `java` command. `classpath` is emitted only when
+/// present (mirroring how [`crate::build::compile::compile_command`] handles
+/// optional javac flags); `class` and `args` become positional arguments.
+fn run_command(classpath: Option<&str>, class: &str, args: &[String]) -> Result<Output, io::Error> {
+    let mut cmd = java_tool_command("java");
+    if let Some(cp) = classpath {
+        cmd.args(["-classpath", cp]);
+    }
+    cmd.arg(class).args(args);
+
+    log::debug!("Running command {:?}", &cmd);
+
+    cmd.stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .output()
+}
+
+/// Build and run a compiled Java class. The runtime classpath is derived from
+/// the `Context`: the compiled `bin` output dir, every jar in `lib` (`lib/*`),
+/// and any local dependency jars declared in the config.
+pub fn execute_java(class: &str, args: &RunArgs, ctx: &Context) -> Result<ExitStatus, BuildError> {
+    let local_deps: Vec<String> = ctx
+        .config
+        .local_package_list()?
+        .into_iter()
+        .map(|dep| dep.path.to_string_lossy().to_string())
+        .collect();
+
+    let ab_bin = path::absolute(&ctx.bin)
+        .map_err(|e| BuildError::IoError(IOError::new("resolving classpath", &ctx.bin, e)))?;
+    let ab_bin_processors = path::absolute(&ctx.bin_processors)
+        .map_err(|e| {
+            BuildError::IoError(IOError::new("resolving processor bin directory", &ctx.bin_processors, e))
+        })?;
+    let ab_lib = path::absolute(&ctx.lib)
+        .map_err(|e| BuildError::IoError(IOError::new("resolving library path", &ctx.lib, e)))?;
+    let ab_lib_annotations = path::absolute(&ctx.lib_annotations).map_err(|e| {
+        BuildError::IoError(IOError::new(
+            "resolving annotation library directory",
+            &ctx.lib_annotations,
+            e,
+        ))
+    })?;
+
+    let classpath = SeperatorList::new(JAVAC_SEPERATOR)
+        .add(ab_bin_processors.display())
+        .add(ab_bin.display())
+        .add_glob(ab_lib_annotations.display())
+        .add_glob(ab_lib.display())
+        .add_slice(&local_deps)
+        .build();
+
+    let output = run_command(Some(&classpath), class, &args.args).map_err(|e| {
+        if e.kind() == io::ErrorKind::NotFound {
+            BuildError::JavaNotFound
+        } else {
+            BuildError::IoError(IOError::new("running java", &ab_bin, e))
+        }
+    })?;
+
+    if output.status.success() {
+        log::info!("Java execution completed successfully");
+    } else {
+        log::warn!(
+            "Java execution failed with exit code: {:?}",
+            output.status.code()
+        );
+    }
+
+    Ok(output.status)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{env, io};
+
+    #[test]
+    fn raw_run_command_resolves_java() -> Result<(), io::Error> {
+        let out = super::run_command(None, "-version", &[])?.status;
+        assert!(out.success());
+        Ok(())
+    }
+
+    #[test]
+    fn test_run_against_fixture() -> Result<(), io::Error> {
+        let mut current = env::current_dir()?;
+        current.push("test_filesystem");
+        current.push("find_main_classes_test");
+        current.push("build");
+        let build = current.clone();
+        let mut lib = current.clone();
+        lib.pop();
+        lib.push("lib");
+
+        let sep = if cfg!(target_os = "windows") {
+            ";"
+        } else {
+            ":"
+        };
+        let classpath = format!("{}{sep}{}/*", build.display(), lib.display());
+
+        let out = super::run_command(Some(&classpath), "Test2", &[])?;
+        assert!(out.status.success(), "Run Command had a non-zero exit code");
+        Ok(())
+    }
+}
+

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -1,3 +1,4 @@
+pub mod execute;
 pub mod interactive_run;
 pub mod run_error;
 pub mod run_java;

--- a/src/run/run_java.rs
+++ b/src/run/run_java.rs
@@ -10,11 +10,11 @@ use crate::{
     build::metadata::BuildMetadata,
     lazy_java::LazyJava,
     lazy_java_error::LazyJavaError,
-    run::{RunError, interactive_run::interactive_find_main},
+    run::{RunError, execute::execute_java, interactive_run::interactive_find_main},
     utils::{
         GlobalContext, IOError,
         jdk_version::warn_runtime_mismatch,
-        processes::{execute_java, java_tool_command},
+        processes::java_tool_command,
     },
 };
 
@@ -43,7 +43,7 @@ impl LazyJava {
             warn_runtime_mismatch(&meta.java_version);
         }
 
-        execute_java(class, &ctx.bin, &ctx.lib, &args.args)?;
+        execute_java(class, args, ctx)?;
 
         log::info!("Java execution completed successfully");
         Ok(())

--- a/src/utils/context/context.rs
+++ b/src/utils/context/context.rs
@@ -1,6 +1,6 @@
 use std::{
     env,
-    path::{self, PathBuf},
+    path::{self, Path, PathBuf},
 };
 
 use colored::Colorize;
@@ -64,6 +64,12 @@ impl Context {
         })?;
 
         let root = root.unwrap_or(env::current_dir().map_err(ContextError::NoRoot)?);
+
+        // Anchor the process to the project root so any relative paths resolved
+        // from here on (e.g. local dependency `path` values, `canonicalize`)
+        // are interpreted relative to the project rather than the invocation
+        // directory.
+        env::set_current_dir(&root).map_err(ContextError::NoDir)?;
 
         let config = match config {
             Some(config) => Ok(config),
@@ -131,6 +137,18 @@ impl Context {
             .project()
             .and_then(|p| p.name())
             .expect("project name is asserted during context construction")
+    }
+
+    /// Resolve a possibly-relative path against the project root. Absolute
+    /// paths are returned unchanged, and relative paths (e.g. a local
+    /// dependency's `path` value) are anchored at [`Context::root`] rather than
+    /// the process working directory, keeping the config portable.
+    pub fn resolve(&self, path: &Path) -> PathBuf {
+        if path.is_relative() {
+            self.root.join(path)
+        } else {
+            path.to_path_buf()
+        }
     }
 
     pub fn assert_src_exists(&self) -> Result<(), ContextError> {

--- a/src/utils/context/context_error.rs
+++ b/src/utils/context/context_error.rs
@@ -13,6 +13,9 @@ pub enum ContextError {
     #[error("Could not read current directory, {0}")]
     NoCurrentDir(io::Error),
 
+    #[error("Could not change the working directory to the project root, {0}")]
+    NoDir(io::Error),
+
     #[error(
         "Could not locate root, no root markers were found, try adding in a root marker or manually specify a root"
     )]
@@ -39,6 +42,9 @@ impl DiagnosticProvider for ContextError {
         match self {
             ContextError::NoCurrentDir(err) => Diagnostic::new("Could not read current directory")
                 .message("Could not determine the current working directory.")
+                .note(err.to_string()),
+            ContextError::NoDir(err) => Diagnostic::new("Could not change working directory")
+                .message("Could not change the working directory to the project root.")
                 .note(err.to_string()),
             ContextError::NoRoot(err) => Diagnostic::new("Could not locate project root")
                 .message("No root markers were found while locating the project.")

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -88,6 +88,10 @@ pub fn read_to_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
     std_fs::read_to_string(path)
 }
 
+pub fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
+    std_fs::read(path)
+}
+
 pub fn read_dir<P: AsRef<Path>>(path: P) -> io::Result<std_fs::ReadDir> {
     std_fs::read_dir(path)
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,9 +4,11 @@ pub mod fs;
 pub mod jdk_version;
 mod join_dir;
 pub mod processes;
+mod seperator_list;
 pub mod timings;
 
 pub use join_dir::join_directory;
+pub use seperator_list::SeperatorList;
 pub use timings::Timings;
 
 mod context;

--- a/src/utils/processes.rs
+++ b/src/utils/processes.rs
@@ -1,12 +1,8 @@
 use std::{
-    env, io,
-    path::{self, Path, PathBuf},
-    process::{Command, ExitStatus, Output, Stdio},
+    env,
+    path::Path,
+    process::Command,
 };
-
-use log::debug;
-
-use crate::{JAVAC_SEPERATOR, build::BuildError, utils::IOError};
 
 /// Build a command for a JDK tool (`javac`, `jar`, `java`). Prefers the
 /// executable from `$JAVA_HOME/bin` and falls back to the system PATH.
@@ -22,102 +18,4 @@ pub fn java_tool_command(tool: &str) -> Command {
         }
     }
     Command::new(tool)
-}
-
-fn run_command(
-    build: &str,
-    lib: &str,
-    class: &str,
-    args: &Vec<String>,
-) -> Result<Output, io::Error> {
-    let sep = JAVAC_SEPERATOR;
-
-    let mut c = java_tool_command("java");
-    let command = c
-        .args(["-classpath", &format!("{}{sep}{}/*", build, lib)])
-        .arg(class)
-        .args(args)
-        .stdin(Stdio::inherit())
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit());
-
-    debug!("Run Command {:?}", &command);
-
-    let output = command.output()?;
-    Ok(output)
-}
-
-pub fn execute_java(
-    classname: &str,
-    classpath: &PathBuf,
-    lib: &Path,
-    args: &Vec<String>,
-) -> Result<ExitStatus, BuildError> {
-    log::info!("Executing Java class: {}", classname);
-    log::debug!("Using classpath: {:?}", classpath);
-    log::debug!("Using library path: {:?}", lib);
-    if !args.is_empty() {
-        log::debug!("Program arguments: {:?}", args);
-    }
-
-    let ab_classpath = path::absolute(classpath)
-        .map_err(|e| BuildError::IoError(IOError::new("resolving classpath", classpath, e)))?;
-    let ab_lib = path::absolute(lib)
-        .map_err(|e| BuildError::IoError(IOError::new("resolving library path", lib, e)))?;
-
-    let output = run_command(
-        ab_classpath.to_str().unwrap(),
-        ab_lib.to_str().unwrap(),
-        classname,
-        args,
-    )
-    .map_err(|e| {
-        if e.kind() == io::ErrorKind::NotFound {
-            BuildError::JavaNotFound
-        } else {
-            BuildError::IoError(IOError::new("running java", &ab_classpath, e))
-        }
-    })?;
-
-    if output.status.success() {
-        log::info!("Java execution completed successfully");
-    } else {
-        log::warn!(
-            "Java execution failed with exit code: {:?}",
-            output.status.code()
-        );
-    }
-
-    Ok(output.status)
-}
-
-#[cfg(test)]
-mod tests {
-    use std::{env, io};
-
-    use crate::utils::processes::execute_java;
-
-    #[test]
-    fn test_run() -> Result<(), io::Error> {
-        let mut current = env::current_dir()?;
-        current.push("test_filesystem");
-        current.push("find_main_classes_test");
-
-        current.push("build");
-        let build = current.clone();
-        let mut lib = current.clone();
-        lib.pop();
-        lib.push("lib");
-
-        let run = execute_java("Test2", &build, &lib, &Vec::new());
-
-        assert!(run.is_ok(), "Run Command was an error");
-
-        assert!(
-            run.unwrap().success(),
-            "Run Command had a none zero exit code"
-        );
-
-        return Ok(());
-    }
 }

--- a/src/utils/seperator_list.rs
+++ b/src/utils/seperator_list.rs
@@ -1,0 +1,116 @@
+use std::fmt::Display;
+
+/// A builder for separator-delimited strings (e.g. javac `-classpath` /
+/// `-processorpath`), where individual entries may carry a trailing `/*` glob
+/// marker.
+///
+/// This avoids hand-assembling strings like
+/// `"{dir1}:{dir2}/*:{dir3}/*"` and keeps the trailing `/*` decision next to
+/// each entry.
+pub struct SeperatorList {
+    sep: char,
+    entries: Vec<String>,
+}
+
+impl SeperatorList {
+    pub fn new(sep: char) -> Self {
+        Self {
+            sep,
+            entries: Vec::new(),
+        }
+    }
+
+    /// Add an entry with no suffix.
+    pub fn add(mut self, value: impl Display) -> Self {
+        self.entries.push(value.to_string());
+        self
+    }
+
+    /// Add an entry followed by a `/*` glob marker.
+    pub fn add_glob(mut self, value: impl Display) -> Self {
+        self.entries.push(format!("{value}/*"));
+        self
+    }
+
+    /// Add each value in the slice as a plain entry.
+    pub fn add_slice(mut self, values: &[impl Display]) -> Self {
+        for value in values {
+            self.entries.push(value.to_string());
+        }
+        self
+    }
+
+    /// Add each value in the slice followed by a `/*` glob marker.
+    pub fn add_slice_glob(mut self, values: &[impl Display]) -> Self {
+        for value in values {
+            self.entries.push(format!("{value}/*"));
+        }
+        self
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Join all entries with the separator and yield the final string.
+    pub fn build(self) -> String {
+        self.entries.join(&self.sep.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SeperatorList;
+
+    #[test]
+    fn empty_builds_empty_string() {
+        assert_eq!(SeperatorList::new(':').build(), "");
+    }
+
+    #[test]
+    fn joins_with_seperator() {
+        let list = SeperatorList::new(';')
+            .add("a")
+            .add("b")
+            .add("c")
+            .build();
+        assert_eq!(list, "a;b;c");
+    }
+
+    #[test]
+    fn supports_glob_suffix_per_entry() {
+        let list = SeperatorList::new(':')
+            .add("lib")
+            .add_glob("jars")
+            .add_glob("more")
+            .build();
+        assert_eq!(list, "lib:jars/*:more/*");
+    }
+
+    #[test]
+    fn adds_plain_slice() {
+        let list = SeperatorList::new(';').add_slice(&["a", "b", "c"]).build();
+        assert_eq!(list, "a;b;c");
+    }
+
+    #[test]
+    fn adds_glob_slice() {
+        let list = SeperatorList::new(';')
+            .add_slice_glob(&["a", "b", "c"])
+            .build();
+        assert_eq!(list, "a/*;b/*;c/*");
+    }
+
+    #[test]
+    fn mixes_single_and_slice() {
+        let list = SeperatorList::new(':')
+            .add("base")
+            .add_slice_glob(&["a", "b"])
+            .build();
+        assert_eq!(list, "base:a/*:b/*");
+    }
+}

--- a/tests/fixtures/local-annot-runtime/lazy-java.toml
+++ b/tests/fixtures/local-annot-runtime/lazy-java.toml
@@ -1,0 +1,5 @@
+[project]
+name = "local-annot-runtime"
+
+[dependancies]
+myannot = { path = "./lib/myannot.jar" }

--- a/tests/fixtures/local-annot-runtime/lib-src/META-INF/services/javax.annotation.processing.Processor
+++ b/tests/fixtures/local-annot-runtime/lib-src/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+runtime.gen.MyProcessor

--- a/tests/fixtures/local-annot-runtime/lib-src/runtime/MyAnno.java
+++ b/tests/fixtures/local-annot-runtime/lib-src/runtime/MyAnno.java
@@ -1,0 +1,8 @@
+package runtime;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MyAnno {
+}

--- a/tests/fixtures/local-annot-runtime/lib-src/runtime/RuntimeHelper.java
+++ b/tests/fixtures/local-annot-runtime/lib-src/runtime/RuntimeHelper.java
@@ -1,0 +1,8 @@
+package runtime;
+
+public class RuntimeHelper {
+
+    public static String greet() {
+        return "hello-from-lib-annotations";
+    }
+}

--- a/tests/fixtures/local-annot-runtime/lib-src/runtime/gen/MyProcessor.java
+++ b/tests/fixtures/local-annot-runtime/lib-src/runtime/gen/MyProcessor.java
@@ -1,0 +1,43 @@
+package runtime.gen;
+
+import java.util.Set;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
+
+public class MyProcessor extends AbstractProcessor {
+
+    private boolean done;
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+        return Set.of("runtime.MyAnno");
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latestSupported();
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        if (roundEnv.processingOver() || done) {
+            return false;
+        }
+        done = true;
+        try {
+            javax.tools.JavaFileObject file =
+                    processingEnv.getFiler().createSourceFile("generated.GeneratedHello");
+            try (java.io.Writer w = file.openWriter()) {
+                w.write("package generated;\n");
+                w.write("public class GeneratedHello {\n");
+                w.write("    public static String msg() { return \"generated-by-processor\"; }\n");
+                w.write("}\n");
+            }
+        } catch (java.io.IOException e) {
+            throw new RuntimeException(e);
+        }
+        return false;
+    }
+}

--- a/tests/fixtures/local-annot-runtime/lib-src/runtime/gen/MyProcessor.java
+++ b/tests/fixtures/local-annot-runtime/lib-src/runtime/gen/MyProcessor.java
@@ -2,6 +2,7 @@ package runtime.gen;
 
 import java.util.Set;
 import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.FilerException;
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.TypeElement;
@@ -35,6 +36,9 @@ public class MyProcessor extends AbstractProcessor {
                 w.write("    public static String msg() { return \"generated-by-processor\"; }\n");
                 w.write("}\n");
             }
+        } catch (FilerException e) {
+            // The generated source already exists from a previous round or
+            // full rebuild; there is nothing to regenerate.
         } catch (java.io.IOException e) {
             throw new RuntimeException(e);
         }

--- a/tests/fixtures/local-annot-runtime/src/app/Main.java
+++ b/tests/fixtures/local-annot-runtime/src/app/Main.java
@@ -1,0 +1,14 @@
+package app;
+
+import runtime.MyAnno;
+import runtime.RuntimeHelper;
+import generated.GeneratedHello;
+
+@MyAnno
+public class Main {
+
+    public static void main(String[] args) {
+        System.out.println(RuntimeHelper.greet());
+        System.out.println(GeneratedHello.msg());
+    }
+}

--- a/tests/suite/local_annot_runtime_test.rs
+++ b/tests/suite/local_annot_runtime_test.rs
@@ -1,5 +1,5 @@
 use assert_cmd::Command;
-use predicates::prelude::predicate;
+use predicates::prelude::{PredicateBooleanExt, predicate};
 use std::path::Path;
 
 /// Locate a JDK tool (`javac`, `jar`), preferring `$JAVA_HOME/bin`, falling
@@ -124,6 +124,27 @@ fn local_lib_jar_is_required_at_runtime() -> Result<(), Box<dyn std::error::Erro
         .success()
         .stdout(predicate::str::contains("hello-from-lib-annotations"))
         .stdout(predicate::str::contains("generated-by-processor"));
+
+    // A second build with no changes must not trigger a full rebuild.
+    let mut cmd = Command::cargo_bin("lazy-java")?;
+    cmd.current_dir(&dest);
+    cmd.args(["build"]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("full build").not());
+
+    // Changing the local jar's contents forces a full rebuild.
+    let greet = dest.join("lib-src").join("runtime").join("RuntimeHelper.java");
+    let original_greet = std::fs::read_to_string(&greet)?;
+    std::fs::write(&greet, original_greet.replace("hello-from-lib-annotations", "hello-2"))?;
+    build_lib_jar(&dest)?;
+
+    let mut cmd = Command::cargo_bin("lazy-java")?;
+    cmd.current_dir(&dest);
+    cmd.args(["build"]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("full build"));
 
     Ok(())
 }

--- a/tests/suite/local_annot_runtime_test.rs
+++ b/tests/suite/local_annot_runtime_test.rs
@@ -1,0 +1,129 @@
+use assert_cmd::Command;
+use predicates::prelude::predicate;
+use std::path::Path;
+
+/// Locate a JDK tool (`javac`, `jar`), preferring `$JAVA_HOME/bin`, falling
+/// back to the system PATH — mirrors the binary's own `java_tool_command`.
+/// Locate a JDK tool (`javac`, `jar`), preferring `$JAVA_HOME/bin`, then falling
+/// back to PATH — mirroring the binary's own tool lookup.
+fn jdk_tool(tool: &str) -> std::process::Command {
+    if let Some(home) = std::env::var_os("JAVA_HOME") {
+        let mut candidate = Path::new(&home).join("bin").join(tool);
+        if cfg!(windows) && candidate.extension().is_none() {
+            candidate.set_extension("exe");
+        }
+        if candidate.is_file() {
+            return std::process::Command::new(candidate);
+        }
+    }
+    std::process::Command::new(tool)
+}
+
+fn fixture_path() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("local-annot-runtime")
+}
+
+/// Build the annotation library jar from the fixture's `lib-src` sources so it
+/// can be referenced as a local dependency (`path=`) by the fixture project.
+fn build_lib_jar(dest: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let lib_src = dest.join("lib-src");
+    let classes = dest.join("jar-classes");
+    std::fs::create_dir_all(&classes)?;
+    std::fs::create_dir_all(dest.join("lib"))?;
+
+    let java_src: Vec<_> = walkdir(&lib_src, "java")?;
+
+    let status = jdk_tool("javac")
+        .args(["-d", classes.to_str().unwrap()])
+        .args(&java_src)
+        .status()?;
+    assert!(status.success(), "javac of the annotation library failed");
+
+    // Include the processor service registration in the built jar so the
+    // library is detected as an annotation processor.
+    copy_dir(&lib_src.join("META-INF"), &classes.join("META-INF"))?;
+
+    let jar = dest.join("lib").join("myannot.jar");
+    let status = jdk_tool("jar")
+        .current_dir(&classes)
+        .args(["--create", "--file", jar.to_str().unwrap(), "."])
+        .status()?;
+    assert!(status.success(), "jar packaging failed");
+    Ok(())
+}
+
+fn walkdir(dir: &Path, ext: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            out.extend(walkdir(&path, ext)?);
+        } else if path.extension().map_or(false, |e| e == ext) {
+            out.push(path.to_string_lossy().to_string());
+        }
+    }
+    Ok(out)
+}
+
+fn copy_dir(from: &Path, to: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    for entry in std::fs::read_dir(from)? {
+        let entry = entry?;
+        let path = entry.path();
+        let dst = to.join(entry.file_name());
+        if path.is_dir() {
+            std::fs::create_dir_all(&dst)?;
+            copy_dir(&path, &dst)?;
+        } else {
+            std::fs::copy(&path, &dst)?;
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn local_lib_jar_is_required_at_runtime() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let dest = tmp.path().join("project");
+    fs_extra::dir::copy(
+        fixture_path(),
+        &dest,
+        &fs_extra::dir::CopyOptions::new().content_only(true),
+    )?;
+
+    // Build the local annotation library jar referenced by lazy-java.toml.
+    build_lib_jar(&dest)?;
+
+    // Build — runs the annotation processor from the local jar, generating code.
+    let mut cmd = Command::cargo_bin("lazy-java")?;
+    cmd.current_dir(&dest);
+    cmd.args(["build"]);
+    cmd.assert().success();
+
+    assert!(
+        dest.join("target")
+            .join("generated-source")
+            .join("generated")
+            .join("GeneratedHello.java")
+            .exists(),
+        "GeneratedHello.java should be produced by the local jar's processor"
+    );
+    assert!(
+        dest.join("target").join("bin").join("app").join("Main.class").exists(),
+        "Main.class should exist after build"
+    );
+
+    // Run — the program needs the annotation library's runtime class at runtime.
+    let mut cmd = Command::cargo_bin("lazy-java")?;
+    cmd.current_dir(&dest);
+    cmd.args(["run", "--no-build", "app.Main"]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("hello-from-lib-annotations"))
+        .stdout(predicate::str::contains("generated-by-processor"));
+
+    Ok(())
+}

--- a/tests/suite/mod.rs
+++ b/tests/suite/mod.rs
@@ -10,6 +10,7 @@ mod group44_test;
 mod import_pom_test;
 mod incremental_build_test;
 mod jdk_release_test;
+mod local_annot_runtime_test;
 mod remove_dependency_test;
 mod resources_copy_test;
 mod sync_build_run_test;

--- a/tests/suite/sync_build_run_test.rs
+++ b/tests/suite/sync_build_run_test.rs
@@ -1,5 +1,5 @@
 use assert_cmd::Command;
-use predicates::prelude::predicate;
+use predicates::prelude::{PredicateBooleanExt, predicate};
 use std::path::Path;
 
 fn fixture_path() -> std::path::PathBuf {
@@ -36,18 +36,60 @@ fn sync_build_run_with_maven_dependency() -> Result<(), Box<dyn std::error::Erro
         "lib dir should exist after add"
     );
 
-    // Step 2: Build
+    // Step 2: Build — first build is a full build
     let mut cmd = Command::cargo_bin("lazy-java")?;
     cmd.current_dir(&dest);
     cmd.args(["build"]);
-    cmd.assert().success();
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("full build"));
 
     assert!(
         dest.join("target").join("bin").join("Main.class").exists(),
         "Main.class should exist after build"
     );
 
-    // Step 3: Run and assert output from commons-lang3 usage
+    // Step 3: A build with no changes must not trigger a full rebuild.
+    let mut cmd = Command::cargo_bin("lazy-java")?;
+    cmd.current_dir(&dest);
+    cmd.args(["build"]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("full build").not());
+
+    // Step 4: Adding a new remote dependency must force a full rebuild.
+    let mut cmd = Command::cargo_bin("lazy-java")?;
+    cmd.current_dir(&dest);
+    cmd.args(["add", "org.apache.commons", "commons-collections4"]);
+    cmd.assert().success();
+
+    let mut cmd = Command::cargo_bin("lazy-java")?;
+    cmd.current_dir(&dest);
+    cmd.args(["build"]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("full build"));
+
+    // Step 5: Adding a remote dependency that bundles an annotation processor
+    // (lands in lib-annotations) must also force a full rebuild.
+    let mut cmd = Command::cargo_bin("lazy-java")?;
+    cmd.current_dir(&dest);
+    cmd.args(["add", "org.immutables", "value"]);
+    cmd.assert().success();
+
+    assert!(
+        dest.join("target").join("lib-annotations").is_dir(),
+        "lib-annotations dir should exist after add"
+    );
+
+    let mut cmd = Command::cargo_bin("lazy-java")?;
+    cmd.current_dir(&dest);
+    cmd.args(["build"]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("full build"));
+
+    // Step 6: Run and assert output from commons-lang3 usage
     let mut cmd = Command::cargo_bin("lazy-java")?;
     cmd.current_dir(&dest);
     cmd.args(["run", "--no-build", "Main"]);


### PR DESCRIPTION
## Summary

Adds support for local `path=` jar dependencies alongside remote Maven dependencies, wires annotation libraries onto the runtime classpath, and cleans up local-dependency error handling.

## Changes
- **Context anchors to project root**: `Context::new_internal` now `chdir`s into the resolved project root so relative paths (e.g. a local dependency's `path` value, `canonicalize`) resolve against the project rather than the invocation directory. Adds a new `ContextError::NoDir` variant with a diagnostic.
- **Local jar runs as an annotation processor**: local jar dependencies are added to `javac`'s `-processorpath`, so a local jar containing an annotation processor can run its annotation-processing stage (not just provide compile/runtime classes).
- **Local jar on the runtime classpath**: `execute_java` now derives the run classpath from `ctx`, including `bin`, `bin_processors`, `lib`, `lib_annotations`, and any local dependency jars.
- **Typo fix**: renamed `ConfigError::LocalDependnecyNotFound` / `LocalDependnecyNotJar` to `LocalDependencyNotFound` / `LocalDependencyNotJar`.
- **Cleanup**: removed the unused `ConfigDependancyParsed` enum.

## Tests
- New e2e `local_annot_runtime_test`: builds a small jar (annotation processor + RUNTIME-retention annotation + runtime helper), adds it as a local `path=` dependency, builds (asserting the processor generated source), and runs (asserting the runtime output comes from the jar's classes).
- All tests green: 80 lib + 24 e2e.