### PR TITLE
Fix spelling/typo errors and add spell-check CI

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,19 @@
+name: spell-check
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  codespell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Spell-check
+        run: |
+          python3 -m venv /tmp/venv-codespell
+          /tmp/venv-codespell/bin/pip install --quiet codespell
+          /tmp/venv-codespell/bin/codespell --toml codespell.toml src tests

--- a/codespell.toml
+++ b/codespell.toml
@@ -1,0 +1,6 @@
+[tool.codespell]
+# Skip the group44 fixture, which is a separate third-party Java project
+# whose identifiers/strings intentionally contain typos as test data.
+skip = "tests/fixtures/group44/**"
+# `ser` is a serialization variable; `errorprone` is a real Maven artifact name.
+ignore-words-list = "ser,errorprone"

--- a/scripts/spell-check.sh
+++ b/scripts/spell-check.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Requires codespell to be installed (e.g. `brew install codespell` or
+# `python3 -m pip install --user codespell`). Matches the `spell-check` CI
+# workflow in `.github/workflows/spell-check.yml`.
+exec codespell --toml codespell.toml src tests

--- a/src/args.rs
+++ b/src/args.rs
@@ -37,12 +37,12 @@ pub enum LazyJavaCommand {
         #[command(flatten)]
         args: CreateArgs,
     },
-    /// Adds a new dependancy
+    /// Adds a new dependency
     Add {
         #[command(flatten)]
         args: AddArgs,
     },
-    /// Removes a dependancy
+    /// Removes a dependency
     Remove {
         #[command(flatten)]
         args: RemoveArgs,
@@ -115,10 +115,10 @@ pub struct BuildCommand {
 }
 #[derive(Subcommand, Debug, Clone)]
 pub enum BuildSubCommand {
-    /// Shows all files and their dependancies
-    Dependancies {},
-    /// Shows all files and their dependants
-    Dependants {},
+    /// Shows all files and their dependencies
+    Dependencies {},
+    /// Shows all files and their dependents
+    Dependents {},
     /// Shows all stale files will be recompiled next build
     Stale {},
     /// Rebuilds the .classfile which is used for jdtls
@@ -136,7 +136,7 @@ pub struct JarArgs {
     #[arg(long)]
     pub entry_point: Option<String>,
 
-    /// Should create a fat jar with all dependancies bundled
+    /// Should create a fat jar with all dependencies bundled
     #[arg(short, long)]
     pub fat: bool,
 
@@ -152,11 +152,11 @@ pub struct CreateArgs {
     #[arg(long, short)]
     pub name: Option<String>,
 
-    /// Whether to initalize a git repository
+    /// Whether to initialize a git repository
     #[arg(long = "git", short = 'g')]
     pub init_git: Option<bool>,
 
-    /// Dont initalize with example files
+    /// Don't initialize with example files
     #[arg(long = "bare", short = 'b')]
     pub bare: bool,
 }
@@ -170,7 +170,7 @@ pub struct AddArgs {
     // the specific version to add
     pub artifact_version: Option<String>,
 
-    // the scope of the dependancy
+    // the scope of the dependency
     pub scope: Option<String>,
 }
 

--- a/src/build/build_error.rs
+++ b/src/build/build_error.rs
@@ -17,10 +17,10 @@ pub enum BuildError {
     #[error("Errors while creating the jar")]
     JarCreationError,
 
-    #[error("Classpath error occured")]
+    #[error("Classpath error occurred")]
     ClasspathError(#[from] ClasspathError),
 
-    #[error("Config error occured")]
+    #[error("Config error occurred")]
     ConfigError(#[from] ConfigError),
 
     #[error("Error serializing build metadata")]

--- a/src/build/build_jar.rs
+++ b/src/build/build_jar.rs
@@ -8,7 +8,12 @@ use walkdir::WalkDir;
 
 use log::debug;
 
-use crate::{Context, args::JarArgs, build::BuildError, utils::{GlobalContext, IOError, fs, processes::java_tool_command}};
+use crate::{
+    Context,
+    args::JarArgs,
+    build::BuildError,
+    utils::{GlobalContext, IOError, fs, processes::java_tool_command},
+};
 
 pub fn build_jar(args: &JarArgs, ctx: &Context) -> Result<(), BuildError> {
     // ISSUE: cheap dry run this is not good and should be improved
@@ -23,7 +28,6 @@ pub fn build_jar(args: &JarArgs, ctx: &Context) -> Result<(), BuildError> {
     }
 
     let output = ctx.target.join("build.jar");
-
     if args.fat {
         build_fat_jar(&output, args, ctx)?;
     } else {
@@ -196,9 +200,10 @@ pub(crate) fn build_manifest(entry_point: &str, ctx: &Context) -> Result<String,
             })?;
             let path = entry.path();
             if path.extension().is_some_and(|e| e == "jar")
-                && let Ok(relative) = path.strip_prefix(&ctx.target) {
-                    class_path.push(relative.to_string_lossy().to_string());
-                }
+                && let Ok(relative) = path.strip_prefix(&ctx.target)
+            {
+                class_path.push(relative.to_string_lossy().to_string());
+            }
         }
     }
 

--- a/src/build/build_java.rs
+++ b/src/build/build_java.rs
@@ -23,8 +23,8 @@ impl LazyJava {
     pub fn build(args: &BuildCommand, ctx: &Context) -> Result<(), BuildError> {
         if let Some(build_command) = &args.command {
             match build_command {
-                BuildSubCommand::Dependancies {} => Self::show_dependancy_graph(ctx),
-                BuildSubCommand::Dependants {} => Self::show_depentants_graph(ctx),
+                BuildSubCommand::Dependencies {} => Self::show_dependency_graph(ctx),
+                BuildSubCommand::Dependents {} => Self::show_dependents_graph(ctx),
                 BuildSubCommand::Stale {} => Self::show_rebuild_files(ctx),
                 BuildSubCommand::Classpath {} => Self::rebuild_classpath(ctx),
                 BuildSubCommand::Jar { args } => Self::build_jar(args, ctx),
@@ -72,7 +72,7 @@ impl LazyJava {
 
                 let stale = graph.stale_files(build_data.as_ref().unwrap().time_stamp);
                 println!(
-                    "{} using incrimental build ({} stale file{})",
+                    "{} using incremental build ({} stale file{})",
                     "Compiling".bold().green(),
                     stale.len(),
                     if stale.len() == 1 { "" } else { "s" }
@@ -87,7 +87,7 @@ impl LazyJava {
             }
         }
 
-        timings.record_current("Incrimental prcoessing");
+        timings.record_current("Incremental processing");
         let jdk = desired_jdk_version(Some(args), Some(ctx));
 
         let mut status: Option<ExitStatus> = None;
@@ -121,14 +121,14 @@ impl LazyJava {
         Ok(())
     }
 
-    fn show_dependancy_graph(ctx: &Context) -> Result<(), BuildError> {
+    fn show_dependency_graph(ctx: &Context) -> Result<(), BuildError> {
         let glob = build_globset(ctx);
 
         let graph = Graph::from_path(&ctx.src, &glob)
             .map_err(|e| IOError::new("finding modified files", &ctx.src, e))?;
 
         let src = &ctx.src;
-        println!("{}", "Dependancy graph".bold().green());
+        println!("{}", "Dependency graph".bold().green());
         for (key, entry) in graph.dependencies.iter() {
             if let Some(name) = key.file_name()
                 && let Ok(rel) = key.strip_prefix(src)
@@ -170,14 +170,14 @@ impl LazyJava {
 
         Ok(())
     }
-    fn show_depentants_graph(ctx: &Context) -> Result<(), BuildError> {
+    fn show_dependents_graph(ctx: &Context) -> Result<(), BuildError> {
         let glob = build_globset(ctx);
 
         let graph = Graph::from_path(&ctx.src, &glob)
             .map_err(|e| IOError::new("finding modified files", &ctx.src, e))?;
 
         let src = &ctx.src;
-        println!("{}", "Dependants graph".bold().green());
+        println!("{}", "Dependents graph".bold().green());
         for (key, entry) in graph.dependents.iter() {
             if let Some(name) = key.file_name()
                 && let Ok(rel) = key.strip_prefix(src)

--- a/src/build/compile.rs
+++ b/src/build/compile.rs
@@ -7,9 +7,9 @@ use std::{
 use log::warn;
 
 use crate::{
-    Context, JAVAC_SEPERATOR,
+    Context, JAVAC_SEPARATOR,
     build::BuildError,
-    utils::{IOError, SeperatorList, join_directory, processes::java_tool_command},
+    utils::{IOError, SeparatorList, join_directory, processes::java_tool_command},
 };
 
 /// Build and run a `javac` command. Each `Option<&str>` maps to a javac flag
@@ -96,7 +96,7 @@ pub fn compile_java(
         "resolving annotation library directory",
         &ctx.lib_annotations,
     )?;
-    let ab_annotation_lib_list = join_directory(&ctx.lib_annotations, JAVAC_SEPERATOR);
+    let ab_annotation_lib_list = join_directory(&ctx.lib_annotations, JAVAC_SEPARATOR);
     let ab_src_generated = resolve("resolving generated source directory", &ctx.src_generated)?;
     let src_generated_destructured = join_directory(&ab_src_generated, ' ');
     let ab_bin_processor = resolve("resolving processor bin directory", &ctx.bin_processors)?;
@@ -108,8 +108,8 @@ pub fn compile_java(
         .map(|dep| dep.path.to_string_lossy().to_string())
         .collect();
 
-    let sep = JAVAC_SEPERATOR;
-    let classpath = SeperatorList::new(sep)
+    let sep = JAVAC_SEPARATOR;
+    let classpath = SeparatorList::new(sep)
         .add(ab_bin_processor.display())
         .add(ab_bin.display())
         .add_glob(ab_annotation_lib.display())
@@ -117,7 +117,7 @@ pub fn compile_java(
         .add_slice(&local_deps)
         .build();
 
-    let processorpath = SeperatorList::new(sep)
+    let processorpath = SeparatorList::new(sep)
         .add(ab_annotation_lib_list)
         .add(ab_bin_processor.display())
         .add_slice(&local_deps)

--- a/src/build/compile_tests.rs
+++ b/src/build/compile_tests.rs
@@ -36,7 +36,7 @@ fn test_compile_command_simple() -> Result<(), std::io::Error> {
 
     let java_file = test_java_file(&src_dir);
 
-    let sep = crate::JAVAC_SEPERATOR;
+    let sep = crate::JAVAC_SEPARATOR;
     let classpath = format!(
         "{}{sep}{}{sep}{}/*{sep}{}/*",
         processor_dir.display(),
@@ -103,7 +103,7 @@ public class Greeting {{
     )
     .unwrap();
 
-    let sep = crate::JAVAC_SEPERATOR;
+    let sep = crate::JAVAC_SEPARATOR;
     let classpath = format!(
         "{}{sep}{}{sep}{}/*{sep}{}/*",
         processor_dir.display(),

--- a/src/build/processors/build.rs
+++ b/src/build/processors/build.rs
@@ -5,7 +5,7 @@ use crate::{
     args::BuildArgs,
     build::BuildError,
     build::compile::compile_java,
-    config::{ConfigProcesserDefinition, ProcesserType},
+    config::{ConfigProcessorDefinition, ProcessorType},
     utils::{IOError, fs},
 };
 
@@ -55,7 +55,7 @@ pub fn build_processors(build_args: &BuildArgs, ctx: &Context) -> Result<(), Bui
 
 fn create_meta_folder(
     ctx: &Context,
-    processors: HashMap<String, ConfigProcesserDefinition>,
+    processors: HashMap<String, ConfigProcessorDefinition>,
 ) -> Result<(), BuildError> {
     let dir = ctx.bin_processors.join("META-INF").join("services");
 
@@ -63,7 +63,7 @@ fn create_meta_folder(
     let mut first = true;
     for (class_name, p) in processors
         .iter()
-        .filter(|(_k, p)| p.kind == ProcesserType::Processor)
+        .filter(|(_k, p)| p.kind == ProcessorType::Processor)
     {
         if !first {
             file_contents.push('\n');
@@ -78,7 +78,7 @@ fn create_meta_folder(
     let service_file = dir.join("javax.annotation.processing.Processor");
     let processor_count = processors
         .iter()
-        .filter(|(_k, p)| p.kind == ProcesserType::Processor)
+        .filter(|(_k, p)| p.kind == ProcessorType::Processor)
         .count();
     log::info!(
         "Writing processor service file to {:?} with {} entr{}",

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -59,7 +59,7 @@ impl ConfigTomlEdit {
         let id = MavenIdBuf::new(add_args.group.clone(), add_args.artifact.clone(), version);
         println!("{} {} to dependency list", "Adding".green().bold(), id);
 
-        let mut deps = self.dependancies_mut().get_or_insert(HashMap::new());
+        let mut deps = self.dependencies_mut().get_or_insert(HashMap::new());
         let mut value = deps.insert_empty(&id.artifact);
 
         value.version_mut().replace(id.version.clone());
@@ -90,7 +90,7 @@ impl ConfigTomlEdit {
             PartialMavenIdBuf::new(remove_args.group.clone(), remove_args.artifact.clone());
 
         let mut version: Option<String> = None;
-        if let Some(deps) = self.dependancies()
+        if let Some(deps) = self.dependencies()
             && let Some(d) = deps.get(&partial_id.artifact)
             && d.group().as_ref() == Some(&partial_id.group)
             && let Some(v) = d.version()
@@ -113,7 +113,7 @@ impl ConfigTomlEdit {
             version
         );
 
-        let mut deps_guard = self.dependancies_mut();
+        let mut deps_guard = self.dependencies_mut();
         if let Some(mut deps) = deps_guard.get_mut() {
             deps.remove(&partial_id.artifact);
         }
@@ -139,7 +139,7 @@ impl ConfigTomlEdit {
     pub fn root_package_list(
         &self,
     ) -> Result<HashMap<PartialMavenIdBuf, RootPackage>, ConfigError> {
-        if let Some(deps) = self.dependancies() {
+        if let Some(deps) = self.dependencies() {
             let mut map = HashMap::new();
             for (k, dep) in deps {
                 let de: Option<RemoteDependency> = dep.to_remote_dependency()?;
@@ -157,7 +157,7 @@ impl ConfigTomlEdit {
         }
     }
     pub fn local_package_list(&self) -> Result<Vec<LocalDependency>, ConfigError> {
-        if let Some(deps) = self.dependancies() {
+        if let Some(deps) = self.dependencies() {
             let mut v = Vec::new();
             for (_key, dep) in deps {
                 let de: Option<LocalDependency> = dep.to_local_dependency()?;

--- a/src/config/config_error.rs
+++ b/src/config/config_error.rs
@@ -11,7 +11,7 @@ use crate::{
 
 #[derive(Error, Debug)]
 pub enum ConfigError {
-    #[error("Could not parse ConfigDependancy missing field '{0}'")]
+    #[error("Could not parse ConfigDependency missing field '{0}'")]
     MissingValue(&'static str),
 
     #[error("Failed to parse")]
@@ -23,7 +23,7 @@ pub enum ConfigError {
     #[error("Error when operating on the lock file")]
     LockFileError(#[from] LockFileError),
 
-    #[error("Maven error occured")]
+    #[error("Maven error occurred")]
     MavenError(#[from] MavenError),
 
     #[error(transparent)]
@@ -32,7 +32,7 @@ pub enum ConfigError {
     #[error("Could not remove because package is not included in config file")]
     PackageNotFound,
 
-    #[error("Could not parse ConfigDependancy unexpected field '{0}'")]
+    #[error("Could not parse ConfigDependency unexpected field '{0}'")]
     UnexpectedValue(&'static str),
 
     #[error("Local dependency path does not exist")]

--- a/src/config/config_structs.rs
+++ b/src/config/config_structs.rs
@@ -26,33 +26,33 @@ pub struct Config {
 
     #[serde(default)]
     #[serde(skip_serializing_if = "is_default")]
-    pub processors: HashMap<String, ConfigProcesserDefinition>,
+    pub processors: HashMap<String, ConfigProcessorDefinition>,
 
     #[serde(default)]
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub dependancies: HashMap<String, ConfigDependancy>,
+    pub dependencies: HashMap<String, ConfigDependency>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, TomlEdit)]
 #[serde(deny_unknown_fields)]
-pub struct ConfigProcesserDefinition {
-    pub kind: ProcesserType,
+pub struct ConfigProcessorDefinition {
+    pub kind: ProcessorType,
     pub path: PathBuf,
     pub package: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, TomlEdit)]
 #[serde(rename_all = "lowercase")]
-pub enum ProcesserType {
+pub enum ProcessorType {
     Annotation,
     Processor,
 }
-impl<'a> ConfigProcesserDefinitionTomlEditView<'a> {
-    pub fn to_processer_definition(&self) -> Result<ConfigProcesserDefinition, ConfigError> {
+impl<'a> ConfigProcessorDefinitionTomlEditView<'a> {
+    pub fn to_processer_definition(&self) -> Result<ConfigProcessorDefinition, ConfigError> {
         let kind = assert(self.kind(), "kind")?;
         let path = assert(self.path(), "path")?;
         let package = assert(self.package(), "package")?;
-        Ok(ConfigProcesserDefinition {
+        Ok(ConfigProcessorDefinition {
             kind,
             path,
             package,
@@ -97,7 +97,7 @@ pub struct ConfigSetup {
 
 #[derive(Debug, Clone, Hash, PartialEq, PartialOrd, Ord, Eq, TomlEdit, Serialize, Deserialize)]
 #[toml_edit(inline)]
-pub struct ConfigDependancy {
+pub struct ConfigDependency {
     pub group: String,
     pub version: String,
     pub scope: Scope,
@@ -112,7 +112,7 @@ pub struct LocalDependency {
     pub path: PathBuf,
 }
 
-impl<'a> ConfigDependancyTomlEditView<'a> {
+impl<'a> ConfigDependencyTomlEditView<'a> {
     pub fn to_remote_dependency(&self) -> Result<Option<RemoteDependency>, ConfigError> {
         let group = self.group();
         let version = self.version();

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -11,7 +11,7 @@ group = "com.example"
 artifact = "my-app"
 version = "1.0.0"
 
-[dependancies]
+[dependencies]
 spring-core = { group_id = "org.springframework", version = "6.0.0" }
 junit = { group_id = "junit", version = "4.13.2" }
 "#
@@ -26,9 +26,9 @@ junit = { group_id = "junit", version = "4.13.2" }
         assert_eq!(loaded.project().unwrap().group().unwrap(), "com.example");
         assert_eq!(loaded.project().unwrap().artifact().unwrap(), "my-app");
         assert_eq!(loaded.project().unwrap().version().unwrap(), "1.0.0");
-        assert!(loaded.dependancies().is_some());
-        assert!(loaded.dependancies().unwrap().contains_key("spring-core"));
-        assert!(loaded.dependancies().unwrap().contains_key("junit"));
+        assert!(loaded.dependencies().is_some());
+        assert!(loaded.dependencies().unwrap().contains_key("spring-core"));
+        assert!(loaded.dependencies().unwrap().contains_key("junit"));
     }
 
     #[test]
@@ -37,13 +37,13 @@ junit = { group_id = "junit", version = "4.13.2" }
 name = "empty"
 "#;
         let loaded = ConfigTomlEdit::parse(toml_str).unwrap();
-        assert!(loaded.dependancies().is_none_or(|d| d.is_empty()));
+        assert!(loaded.dependencies().is_none_or(|d| d.is_empty()));
     }
 
     #[test]
     fn default_config_has_empty_dependencies() {
         let loaded = ConfigTomlEdit::parse("").unwrap();
-        assert!(loaded.dependancies().is_none_or(|d| d.is_empty()));
+        assert!(loaded.dependencies().is_none_or(|d| d.is_empty()));
     }
 
     #[test]
@@ -51,11 +51,11 @@ name = "empty"
         let toml_str = r#"[project]
 name = "test"
 
-[dependancies]
+[dependencies]
 my-lib = { group = "com.example", version = "2.0.0" }
 "#;
         let loaded = ConfigTomlEdit::parse(toml_str).unwrap();
-        let deps = loaded.dependancies().unwrap();
+        let deps = loaded.dependencies().unwrap();
         let entry = deps.get("my-lib").unwrap();
         assert_eq!(entry.group().unwrap(), "com.example");
         assert_eq!(entry.version().unwrap(), "2.0.0");
@@ -69,7 +69,7 @@ my-lib = { group = "com.example", version = "2.0.0" }
         let toml_str = r#"[project]
 name = "test-project"
 
-[dependancies]
+[dependencies]
 test-lib = { group = "com.test", version = "0.1.0" }
 "#;
         let config = ConfigTomlEdit::parse(toml_str)?;
@@ -77,7 +77,7 @@ test-lib = { group = "com.test", version = "0.1.0" }
 
         let loaded = ConfigTomlEdit::fetch(root)?;
         assert_eq!(loaded.project().unwrap().name().unwrap(), "test-project");
-        assert!(!loaded.dependancies().unwrap().is_empty());
+        assert!(!loaded.dependencies().unwrap().is_empty());
 
         Ok(())
     }
@@ -95,7 +95,7 @@ name = "empty"
         config.write(root)?;
 
         let loaded = ConfigTomlEdit::fetch(root)?;
-        assert!(loaded.dependancies().is_none_or(|d| d.is_empty()));
+        assert!(loaded.dependencies().is_none_or(|d| d.is_empty()));
 
         Ok(())
     }
@@ -118,7 +118,7 @@ artifact = "my-app"
 version = "1.0.0"
 
 # Dependencies section comment
-[dependancies]
+[dependencies]
 # spring-core comment
 spring-core = { group = "org.springframework", version = "6.0.0" }
 junit = { group = "junit", version = "4.13.2" } # junit inline
@@ -149,7 +149,7 @@ junit = { group = "junit", version = "4.13.2" } # junit inline
         let toml_str = r#"[project]
 name = "ordered"
 
-[dependancies]
+[dependencies]
 zeta = { group = "z.org", version = "1.0.0" }
 alpha = { group = "a.org", version = "2.0.0" }
 delta = { group = "d.org", version = "3.0.0" }
@@ -171,11 +171,11 @@ delta = { group = "d.org", version = "3.0.0" }
 name = "test"
 
 # Existing deps
-[dependancies]
+[dependencies]
 existing = { group = "com.existing", version = "1.0.0" }
 "#;
         let mut config = ConfigTomlEdit::parse(toml_str).unwrap();
-        let mut deps = config.dependancies_mut().get_or_insert(HashMap::new());
+        let mut deps = config.dependencies_mut().get_or_insert(HashMap::new());
         let mut value = deps.insert_empty("new-dep");
         value.group_mut().replace("com.new".to_string());
         value.version_mut().replace("2.0.0".to_string());
@@ -200,12 +200,12 @@ existing = { group = "com.existing", version = "1.0.0" }
         let toml_str = r#"[project]
 name = "test"
 
-[dependancies]
+[dependencies]
 oldest = { group = "o.org", version = "1.0.0" }
 older = { group = "r.org", version = "2.0.0" }
 "#;
         let mut config = ConfigTomlEdit::parse(toml_str).unwrap();
-        let mut deps = config.dependancies_mut().get_or_insert(HashMap::new());
+        let mut deps = config.dependencies_mut().get_or_insert(HashMap::new());
         let mut value = deps.insert_empty("newest");
         value.group_mut().replace("n.org".to_string());
         value.version_mut().replace("3.0.0".to_string());
@@ -229,14 +229,14 @@ older = { group = "r.org", version = "2.0.0" }
 name = "test"
 
 # Deps header
-[dependancies]
+[dependencies]
 aaa = { group = "a.org", version = "1.0.0" } # a comment
 # b comment
 bbb = { group = "b.org", version = "2.0.0" }
 ccc = { group = "c.org", version = "3.0.0" }
 "#;
         let mut config = ConfigTomlEdit::parse(toml_str).unwrap();
-        if let Some(mut deps) = config.dependancies_mut().get_mut() {
+        if let Some(mut deps) = config.dependencies_mut().get_mut() {
             deps.remove("bbb");
         }
         let output = config.to_toml_string();

--- a/src/create/create_error.rs
+++ b/src/create/create_error.rs
@@ -4,10 +4,10 @@ use crate::utils::{Diagnostic, DiagnosticProvider, IOError};
 
 #[derive(Error, Debug)]
 pub enum CreateError {
-    #[error("Couldnt prompt user for project name")]
+    #[error("Couldn't prompt user for project name")]
     ProjectNameError,
 
-    #[error("Couldnt create project directory")]
+    #[error("Couldn't create project directory")]
     CreateDirectoryError,
 
     #[error(transparent)]

--- a/src/create/interactive.rs
+++ b/src/create/interactive.rs
@@ -15,7 +15,7 @@ pub fn interactive_project_name() -> Result<String, CreateError> {
 
 pub fn interactive_git_init_name() -> Result<bool, CreateError> {
     log::debug!("Prompting user for git initialization");
-    let init = Confirm::new("Initalize git repository (y/n):")
+    let init = Confirm::new("Initialize git repository (y/n):")
         .prompt()
         .map_err(|e| {
             log::error!("Failed to get git initialization choice from user: {}", e);

--- a/src/find/find_java.rs
+++ b/src/find/find_java.rs
@@ -15,7 +15,7 @@ impl LazyJava {
             Vec::new()
         };
         let mains =
-            find_main_classes(&ctx.src, &exclude).map_err(LazyJavaError::CouldntFindMains)?;
+            find_main_classes(&ctx.src, &exclude).map_err(LazyJavaError::CouldNotFindMains)?;
         log::debug!("Found {} main classes", mains.len());
 
         for main in mains {

--- a/src/generate/pom.rs
+++ b/src/generate/pom.rs
@@ -9,7 +9,7 @@ use crate::{
     generate::GenerateError,
     lock_file::LockFile,
     maven_central::pom::{
-        AnnotationProcessorPaths, Build, Configuration, DependancyType, Dependencies, Dependency,
+        AnnotationProcessorPaths, Build, Configuration, DependencyType, Dependencies, Dependency,
         MavenPom, Plugin, Plugins, ProcessorPath, Properties, Scope,
     },
     utils::{IOError, XmlSerializeError, fs, jdk_version::desired_jdk_version},
@@ -85,7 +85,7 @@ fn create_pom(ctx: &Context) -> Result<MavenPom, GenerateError> {
         }
     };
 
-    let mut dependancies: Vec<Dependency> = lockfile
+    let mut dependencies: Vec<Dependency> = lockfile
         .packages
         .into_iter()
         .filter(|d| d.root)
@@ -99,13 +99,13 @@ fn create_pom(ctx: &Context) -> Result<MavenPom, GenerateError> {
             classifier: None,
         })
         .collect();
-    dependancies.sort_by(|a, b| {
+    dependencies.sort_by(|a, b| {
         a.group_id
             .cmp(&b.group_id)
             .then(a.artifact_id.cmp(&b.artifact_id))
     });
-    let dependancies = Dependencies {
-        dependency: dependancies,
+    let dependencies = Dependencies {
+        dependency: dependencies,
     };
 
     Ok(MavenPom {
@@ -113,8 +113,8 @@ fn create_pom(ctx: &Context) -> Result<MavenPom, GenerateError> {
         group_id: group_id.to_string(),
         artifact_id: artifact_id.to_string(),
         version: version_id.to_string(),
-        packaging: DependancyType::Jar,
-        dependencies: Some(dependancies),
+        packaging: DependencyType::Jar,
+        dependencies: Some(dependencies),
         dependency_management: None,
         properties: Properties {
             map: HashMap::from([("maven.compiler.release".to_string(), jdk)]),

--- a/src/import/pom.rs
+++ b/src/import/pom.rs
@@ -49,7 +49,7 @@ pub fn import_pom(root: &Path, args: &ImportPomArgs) -> Result<(), ImportError> 
 
     let mut config = ConfigTomlEdit::parse("")?;
     if let Some(deps) = pom.dependencies {
-        let mut tomldeps = config.dependancies_mut().get_or_insert(HashMap::new());
+        let mut tomldeps = config.dependencies_mut().get_or_insert(HashMap::new());
         for dep in deps.dependency {
             let version = match &dep.version {
                 Some(v) => v.clone(),

--- a/src/lazy_java_error.rs
+++ b/src/lazy_java_error.rs
@@ -25,14 +25,14 @@ pub enum LazyJavaError {
     #[error("Could not create project")]
     CreateError(#[from] CreateError),
 
-    #[error("Build error occured")]
+    #[error("Build error occurred")]
     BuildError(#[from] BuildError),
 
-    #[error("Context error occured")]
+    #[error("Context error occurred")]
     ContextError(#[from] ContextError),
 
     #[error("Unable to find main classes, {0}")]
-    CouldntFindMains(io::Error),
+    CouldNotFindMains(io::Error),
 
     #[error("Unable to remove build directory when cleaning, {0}")]
     NoRemoveBuild(io::Error),
@@ -40,13 +40,13 @@ pub enum LazyJavaError {
     #[error("IO error: {0}")]
     IoError(#[from] io::Error),
 
-    #[error("Run error occured")]
+    #[error("Run error occurred")]
     RunError(#[from] RunError),
 
-    #[error("Classpath error occured")]
+    #[error("Classpath error occurred")]
     ClasspathError(#[from] ClasspathError),
 
-    #[error("Maven error occured")]
+    #[error("Maven error occurred")]
     MavenError(#[from] MavenError),
 
     #[error("Error when operating on lock file")]
@@ -67,7 +67,7 @@ impl DiagnosticProvider for LazyJavaError {
             LazyJavaError::CreateError(err) => err.diagnostic(),
             LazyJavaError::BuildError(err) => err.diagnostic(),
             LazyJavaError::ContextError(err) => err.diagnostic(),
-            LazyJavaError::CouldntFindMains(err) => Diagnostic::new("Unable to find main classes")
+            LazyJavaError::CouldNotFindMains(err) => Diagnostic::new("Unable to find main classes")
                 .message("Could not locate any main classes in the project.")
                 .help("Create a main class, then try running again.")
                 .note(err.to_string()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub const LOCK_FILE_NAME: &str = "lazy-java.lock";
 pub const CONFIG_FILE_NAME: &str = "lazy-java.toml";
 pub const BUILD_METADATA_NAME: &str = ".lazy-java-build";
 
-pub const JAVAC_SEPERATOR: char = if cfg!(target_os = "windows") {
+pub const JAVAC_SEPARATOR: char = if cfg!(target_os = "windows") {
     ';'
 } else {
     ':'

--- a/src/lock_file/fetch_packages.rs
+++ b/src/lock_file/fetch_packages.rs
@@ -22,7 +22,7 @@ impl LockFile {
         if list.is_empty() {
             return Ok(0);
         }
-        println!("    {} missing dependancies", "Fetching".bold().green());
+        println!("    {} missing dependencies", "Fetching".bold().green());
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()

--- a/src/lock_file/lock_file.rs
+++ b/src/lock_file/lock_file.rs
@@ -15,7 +15,7 @@ use crate::{
     lock_file::LockFileError,
     maven_central::{
         MavenId, MavenIdBuf, PartialMavenIdBuf,
-        pom::{DependancyType, MavenDependancyList, Scope},
+        pom::{DependencyType, MavenDependencyList, Scope},
     },
     utils::{IOError, TomlDeserializeError, TomlSerializeError, fs},
 };
@@ -35,9 +35,9 @@ pub struct LockFilePackage {
 
     pub url: String,
 
-    pub dependancies: Vec<MavenIdBuf>,
+    pub dependencies: Vec<MavenIdBuf>,
 
-    pub packaging: DependancyType,
+    pub packaging: DependencyType,
 
     pub root: bool,
     pub scope: Scope,
@@ -89,7 +89,7 @@ impl LockFile {
     pub fn write(&mut self, root: &Path) -> Result<(), LockFileError> {
         self.packages.sort();
         for pkg in &mut self.packages {
-            pkg.dependancies.sort();
+            pkg.dependencies.sort();
             pkg.annotations.sort();
         }
 
@@ -106,7 +106,7 @@ impl LockFile {
         id: MavenIdBuf,
         scope: Option<Scope>,
     ) -> Result<isize, LockFileError> {
-        let list: Vec<LockFilePackage> = MavenDependancyList::new(id, scope)?
+        let list: Vec<LockFilePackage> = MavenDependencyList::new(id, scope)?
             .into_iter()
             .map(|m| m.into())
             .collect();
@@ -116,7 +116,7 @@ impl LockFile {
             .into_iter()
             .map(|p| {
                 (
-                    MavenDependancyList::hash_maven_bom_id(&p.id.group, &p.id.artifact),
+                    MavenDependencyList::hash_maven_bom_id(&p.id.group, &p.id.artifact),
                     p,
                 )
             })
@@ -124,7 +124,7 @@ impl LockFile {
 
         for package in list {
             let hash =
-                MavenDependancyList::hash_maven_bom_id(&package.id.group, &package.id.artifact);
+                MavenDependencyList::hash_maven_bom_id(&package.id.group, &package.id.artifact);
             if let Some(old) = map.remove(&hash) {
                 let old_version = Maven3ArtifactVersion::new(&old.id.version);
                 let new_version = Maven3ArtifactVersion::new(&package.id.version);
@@ -191,7 +191,7 @@ impl LockFile {
         &mut self,
         ctx: &ContextNoConfig,
     ) -> Result<isize, LockFileError> {
-        println!("{} dependancies", "Syncing".green().bold(),);
+        println!("{} dependencies", "Syncing".green().bold(),);
         let mut added: isize = 0;
         let mut removed: isize = 0;
         let mut map: HashMap<String, &mut LockFilePackage> = self
@@ -208,9 +208,9 @@ impl LockFile {
 
         let plural = |change: isize| {
             if change.abs() != 1 {
-                "dependancies"
+                "dependencies"
             } else {
-                "dependancy"
+                "dependency"
             }
         };
         if added != 0 {

--- a/src/lock_file/lock_file_error.rs
+++ b/src/lock_file/lock_file_error.rs
@@ -40,7 +40,7 @@ pub enum LockFileError {
 impl DiagnosticProvider for LockFileError {
     fn diagnostic(&self) -> Diagnostic {
         match self {
-            LockFileError::DownloadFailed(code) => Diagnostic::new("Downloading dependancy failed")
+            LockFileError::DownloadFailed(code) => Diagnostic::new("Downloading dependency failed")
                 .message(format!("Downloading failed with code {}", code)),
             LockFileError::ParseFailed(err) => err.diagnostic(),
             LockFileError::SerializeFailed(err) => err.diagnostic(),

--- a/src/lock_file/remove.rs
+++ b/src/lock_file/remove.rs
@@ -26,7 +26,7 @@ impl LockFile {
             info!("Removed package {}", package.id);
 
             self.packages.iter_mut().for_each(|p| {
-                p.dependancies.retain(|dep| dep != &package.id);
+                p.dependencies.retain(|dep| dep != &package.id);
             });
 
             Ok(package)
@@ -56,7 +56,7 @@ impl LockFile {
                 in_degree[i] += 1;
             }
             let edges: Vec<usize> = p
-                .dependancies
+                .dependencies
                 .iter()
                 .filter_map(|dep| id_to_idx.get(dep).copied())
                 .collect();
@@ -90,7 +90,7 @@ impl LockFile {
         let remaining_ids: HashSet<MavenIdBuf> =
             self.packages.iter().map(|p| p.id.clone()).collect();
         for p in &mut self.packages {
-            p.dependancies.retain(|dep| remaining_ids.contains(dep));
+            p.dependencies.retain(|dep| remaining_ids.contains(dep));
         }
     }
 }

--- a/src/lock_file/remove_tests.rs
+++ b/src/lock_file/remove_tests.rs
@@ -2,7 +2,7 @@
 mod tests {
     use crate::{
         lock_file::{LockFile, LockFilePackage},
-        maven_central::{MavenIdBuf, pom::DependancyType},
+        maven_central::{MavenIdBuf, pom::DependencyType},
     };
 
     fn package(id: &str, deps: &[&str]) -> LockFilePackage {
@@ -19,8 +19,8 @@ mod tests {
             id: MavenIdBuf::new(parts[0], parts[1], parts[2]),
             file_name: String::new(),
             url: String::new(),
-            dependancies: dep_ids,
-            packaging: DependancyType::Jar,
+            dependencies: dep_ids,
+            packaging: DependencyType::Jar,
             root: false,
             scope: crate::maven_central::pom::Scope::Compile,
             annotations: Vec::new(),
@@ -70,7 +70,7 @@ mod tests {
     }
 
     #[test]
-    fn transitive_cleans_dependancy_lists() {
+    fn transitive_cleans_dependency_lists() {
         let mut lock = lockfile(vec![
             package("g:x:1.0", &["g:a:1.0"]),
             package("g:a:1.0", &["g:b:1.0", "g:c:1.0"]),

--- a/src/lsp/classpath_error.rs
+++ b/src/lsp/classpath_error.rs
@@ -17,7 +17,7 @@ pub enum ClasspathError {
     #[error("Could not read lib folder at {0}, OS Error: {1}")]
     OSErrorLib(String, io::Error),
 
-    #[error("Could not write classpath file, attemping to write it at {0}, OS Error: {1}")]
+    #[error("Could not write classpath file, attempting to write it at {0}, OS Error: {1}")]
     ClasspathWrite(String, io::Error),
 
     #[error("Could not serialize classpath, Error: {0}")]

--- a/src/maven_central/pom/dependency_list.rs
+++ b/src/maven_central/pom/dependency_list.rs
@@ -20,25 +20,25 @@ use crate::maven_central::{
     MavenError, MavenId, MavenIdBuf,
     fetch_async::fetch_pom,
     pom::{
-        dependancy_list_structs::{
-            Cache, Dependancy, DependancyList, MavenDependancy, MavenDependancyList, PomState,
+        dependency_list_structs::{
+            Cache, Dependency, DependencyList, MavenDependency, MavenDependencyList, PomState,
         },
-        pom::{DependancyType, MavenPom, Scope},
+        pom::{DependencyType, MavenPom, Scope},
     },
 };
 
 #[derive(Clone)]
 struct ResolveContext {
     cache: Cache,
-    list: DependancyList,
+    list: DependencyList,
     client: Client,
 }
 
-impl MavenDependancyList {
+impl MavenDependencyList {
     async fn runtime_entry(
         id: MavenIdBuf,
         scope: Option<Scope>,
-    ) -> Result<Vec<MavenDependancy>, MavenError> {
+    ) -> Result<Vec<MavenDependency>, MavenError> {
         log::info!("Creating POM list for {}", id);
 
         let cache = Arc::new(RwLock::new(HashMap::new()));
@@ -52,7 +52,7 @@ impl MavenDependancyList {
         };
         Self::resolve_pom(id.clone(), ctx, scope).await?;
 
-        let mut map: HashMap<u64, MavenDependancy> = HashMap::new();
+        let mut map: HashMap<u64, MavenDependency> = HashMap::new();
 
         let dep_list = Arc::into_inner(dep_list)
             .expect("Runtime completed Arc released")
@@ -72,9 +72,9 @@ impl MavenDependancyList {
                 map.insert(hash, dep);
             }
         }
-        let mut list: Vec<MavenDependancy> = map.into_values().collect();
+        let mut list: Vec<MavenDependency> = map.into_values().collect();
 
-        // set the root dependancy
+        // set the root dependency
         for dep in list.iter_mut() {
             if dep.id == id {
                 dep.root = true;
@@ -82,7 +82,7 @@ impl MavenDependancyList {
         }
         Ok(list)
     }
-    pub fn new(id: MavenIdBuf, scope: Option<Scope>) -> Result<Vec<MavenDependancy>, MavenError> {
+    pub fn new(id: MavenIdBuf, scope: Option<Scope>) -> Result<Vec<MavenDependency>, MavenError> {
         let rt = Runtime::new().unwrap();
 
         rt.block_on(Self::runtime_entry(id, scope))
@@ -124,7 +124,7 @@ impl MavenDependancyList {
 
         let mut pom = fetch_pom(ctx.client.clone(), &id.as_maven_id()).await?;
 
-        if let DependancyType::Other(other_packaging) = &pom.packaging {
+        if let DependencyType::Other(other_packaging) = &pom.packaging {
             log::error!(
                 "Found unknown packaging type \"{}\" on {}:{}:{}",
                 other_packaging,
@@ -153,14 +153,14 @@ impl MavenDependancyList {
 
             pom.properties.map = parent_props;
 
-            // backwords for right now
+            // backwards for right now
             pom.dependency_management_map
                 .extend(parent_pom.dependency_management_map.clone());
 
             Self::resolve_properties_inital(&mut pom);
         }
 
-        let mut dependancy_list: Vec<Dependancy> = Vec::new();
+        let mut dependency_list: Vec<Dependency> = Vec::new();
 
         if scope != Some(Scope::Provided) {
             let bom_handles = Self::bom_handles(&pom, &ctx);
@@ -179,16 +179,16 @@ impl MavenDependancyList {
                     bom_props.extend(pom.properties.map);
                     pom.properties.map = bom_props;
 
-                    // backwords
+                    // backwards
                     pom.dependency_management_map
                         .extend(bom_pom.dependency_management_map.clone());
                 }
             }
             Self::resolve_properties_inital(&mut pom);
 
-            // tracks the dep list for the dependancy list
+            // tracks the dep list for the dependency list
 
-            let dependacy_handles = Self::dependancy_handles(&pom, &ctx);
+            let dependacy_handles = Self::dependency_handles(&pom, &ctx);
             if let Some(mut dependacy_handles) = dependacy_handles {
                 while let Some(result) = dependacy_handles.join_next().await {
                     let (dep_result, id) = result?;
@@ -197,21 +197,21 @@ impl MavenDependancyList {
                     dep_props.extend(pom.properties.map);
                     pom.properties.map = dep_props;
 
-                    dependancy_list.push(Dependancy { id });
+                    dependency_list.push(Dependency { id });
                 }
             }
         }
 
         Self::resolve_properties_final(&mut pom);
 
-        if pom.packaging != DependancyType::Pom
-            && !matches!(pom.packaging, DependancyType::Other(_))
+        if pom.packaging != DependencyType::Pom
+            && !matches!(pom.packaging, DependencyType::Other(_))
         {
             let mut write_list = ctx.list.write();
-            write_list.push(MavenDependancy {
+            write_list.push(MavenDependency {
                 id: MavenIdBuf::new(id.group, id.artifact, id.version),
-                dependancy_type: pom.packaging.clone(),
-                dependancies: dependancy_list,
+                dependency_type: pom.packaging.clone(),
+                dependencies: dependency_list,
                 root: false,
                 scope: Scope::Compile,
             });
@@ -332,7 +332,7 @@ impl MavenDependancyList {
         }
         None
     }
-    fn dependancy_handles(
+    fn dependency_handles(
         pom: &MavenPom,
         ctx: &ResolveContext,
     ) -> Option<JoinSet<(Result<Arc<MavenPom>, MavenError>, MavenIdBuf)>> {

--- a/src/maven_central/pom/dependency_list_structs.rs
+++ b/src/maven_central/pom/dependency_list_structs.rs
@@ -8,11 +8,11 @@ use crate::{
     maven_central::{
         MavenIdBuf,
         fetch::full_maven_url,
-        pom::{DependancyType, MavenPom, Scope},
+        pom::{DependencyType, MavenPom, Scope},
     },
 };
 
-pub struct MavenDependancyList {}
+pub struct MavenDependencyList {}
 
 pub enum PomState {
     Resolved(Arc<MavenPom>),
@@ -20,40 +20,40 @@ pub enum PomState {
 }
 
 pub type Cache = Arc<RwLock<HashMap<u64, PomState>>>;
-pub type DependancyList = Arc<RwLock<Vec<MavenDependancy>>>;
+pub type DependencyList = Arc<RwLock<Vec<MavenDependency>>>;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct MavenDependancy {
+pub struct MavenDependency {
     pub id: MavenIdBuf,
-    pub dependancy_type: DependancyType,
-    pub dependancies: Vec<Dependancy>,
+    pub dependency_type: DependencyType,
+    pub dependencies: Vec<Dependency>,
     pub scope: Scope,
     pub root: bool,
 }
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Dependancy {
+pub struct Dependency {
     pub id: MavenIdBuf,
 }
 
-impl From<MavenDependancy> for LockFilePackage {
-    fn from(value: MavenDependancy) -> Self {
-        let ext = |t: &DependancyType| match t {
-            DependancyType::Jar => "jar",
-            DependancyType::War => "war",
-            DependancyType::Bundle => "jar",
-            _ => panic!("Unsupported dependancy type"),
+impl From<MavenDependency> for LockFilePackage {
+    fn from(value: MavenDependency) -> Self {
+        let ext = |t: &DependencyType| match t {
+            DependencyType::Jar => "jar",
+            DependencyType::War => "war",
+            DependencyType::Bundle => "jar",
+            _ => panic!("Unsupported dependency type"),
         };
-        let ext_str = ext(&value.dependancy_type);
+        let ext_str = ext(&value.dependency_type);
 
         let url = full_maven_url(&value.id.as_maven_id(), ext_str);
         let file_name = format!("{}-{}.{}", &value.id.artifact, &value.id.version, ext_str);
 
         LockFilePackage {
-            packaging: value.dependancy_type,
+            packaging: value.dependency_type,
             id: value.id,
             url,
             file_name,
-            dependancies: value.dependancies.into_iter().map(|v| v.id).collect(),
+            dependencies: value.dependencies.into_iter().map(|v| v.id).collect(),
             root: value.root,
             annotations: Vec::new(),
             scope: value.scope,

--- a/src/maven_central/pom/mod.rs
+++ b/src/maven_central/pom/mod.rs
@@ -1,10 +1,10 @@
-mod dependancy_list;
-mod dependancy_list_structs;
+mod dependency_list;
+mod dependency_list_structs;
 mod pom;
 mod pom_deserialize;
 mod pom_properties_deserializer;
 
-pub use dependancy_list_structs::MavenDependancyList;
+pub use dependency_list_structs::MavenDependencyList;
 pub use pom::*;
 
 #[cfg(test)]

--- a/src/maven_central/pom/pom.rs
+++ b/src/maven_central/pom/pom.rs
@@ -20,7 +20,7 @@ pub struct MavenPom {
     pub version: String,
 
     #[serde(default)]
-    pub packaging: DependancyType,
+    pub packaging: DependencyType,
 
     pub dependencies: Option<Dependencies>,
 
@@ -73,7 +73,7 @@ pub struct Dependency {
     pub optional: bool,
 
     #[serde(rename = "type", default)]
-    pub dependency_type: DependancyType,
+    pub dependency_type: DependencyType,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub classifier: Option<String>,
@@ -112,7 +112,7 @@ pub enum Scope {
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, PartialOrd, Ord, AsRefStr)]
 #[strum(serialize_all = "lowercase")]
-pub enum DependancyType {
+pub enum DependencyType {
     #[default]
     Jar,
     War,
@@ -121,7 +121,7 @@ pub enum DependancyType {
 
     Other(String),
 }
-impl Serialize for DependancyType {
+impl Serialize for DependencyType {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -130,7 +130,7 @@ impl Serialize for DependancyType {
     }
 }
 
-impl<'de> Deserialize<'de> for DependancyType {
+impl<'de> Deserialize<'de> for DependencyType {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -138,11 +138,11 @@ impl<'de> Deserialize<'de> for DependancyType {
         let s = String::deserialize(deserializer)?;
 
         Ok(match s.as_str() {
-            "jar" => DependancyType::Jar,
-            "war" => DependancyType::War,
-            "pom" => DependancyType::Pom,
-            "bundle" => DependancyType::Bundle,
-            _ => DependancyType::Other(s), // Catches absolutely any other string safely
+            "jar" => DependencyType::Jar,
+            "war" => DependencyType::War,
+            "pom" => DependencyType::Pom,
+            "bundle" => DependencyType::Bundle,
+            _ => DependencyType::Other(s), // Catches absolutely any other string safely
         })
     }
 }

--- a/src/maven_central/pom/pom_deserialize.rs
+++ b/src/maven_central/pom/pom_deserialize.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::{
     maven_central::{
         MavenError, MavenId,
-        pom::{dependancy_list_structs::MavenDependancyList, pom::MavenPom},
+        pom::{dependency_list_structs::MavenDependencyList, pom::MavenPom},
     },
     utils::XmlDeserializeError,
 };
@@ -25,7 +25,7 @@ impl MavenPom {
                 .iter()
                 .map(|bom| {
                     let hash =
-                        MavenDependancyList::hash_maven_bom_id(&bom.group_id, &bom.artifact_id);
+                        MavenDependencyList::hash_maven_bom_id(&bom.group_id, &bom.artifact_id);
 
                     (
                         hash,

--- a/src/maven_central/pom/tests.rs
+++ b/src/maven_central/pom/tests.rs
@@ -4,7 +4,7 @@ mod tests {
     use crate::maven_central::{
         MavenIdBuf,
         pom::{
-            MavenDependancyList, dependancy_list_structs::MavenDependancy, pom::DependancyType,
+            MavenDependencyList, dependency_list_structs::MavenDependency, pom::DependencyType,
             pom::Scope,
         },
     };
@@ -17,9 +17,9 @@ mod tests {
     }
 
     #[test]
-    fn test_maven_dependancy_list_simple() {
+    fn test_maven_dependency_list_simple() {
         // Test creating a dependency list for a simple artifact (junit has no dependencies)
-        let result = MavenDependancyList::new(MavenIdBuf::new("junit", "junit", "4.13.2"), None);
+        let result = MavenDependencyList::new(MavenIdBuf::new("junit", "junit", "4.13.2"), None);
         assert!(
             result.is_ok(),
             "Failed to create dependency list: {:?}",
@@ -40,9 +40,9 @@ mod tests {
     }
 
     #[test]
-    fn test_maven_dependancy_list_excludes_pom_packaging() {
+    fn test_maven_dependency_list_excludes_pom_packaging() {
         // Test that POM-type dependencies are excluded from the list
-        let result = MavenDependancyList::new(
+        let result = MavenDependencyList::new(
             MavenIdBuf::new("com.fasterxml.jackson.core", "jackson-databind", "2.15.0"),
             None,
         );
@@ -57,7 +57,7 @@ mod tests {
         // All dependencies should be JAR, not POM
         for dep in &dep_list {
             assert!(
-                dep.dependancy_type != DependancyType::Pom,
+                dep.dependency_type != DependencyType::Pom,
                 "POM dependencies should be excluded from list, found: {}:{}",
                 dep.id.group,
                 dep.id.artifact
@@ -66,9 +66,9 @@ mod tests {
     }
 
     #[test]
-    fn test_maven_dependancy_list_invalid_artifact() {
+    fn test_maven_dependency_list_invalid_artifact() {
         // Test that invalid artifacts produce errors
-        let result = MavenDependancyList::new(
+        let result = MavenDependencyList::new(
             MavenIdBuf::new("invalid.id.group", "invalid.id.artifact", "1.0.0"),
             None,
         );
@@ -76,9 +76,9 @@ mod tests {
     }
 
     #[test]
-    fn test_maven_dependancy_list_against_real_list() {
+    fn test_maven_dependency_list_against_real_list() {
         // Test that transitive dependencies are included
-        let result = MavenDependancyList::new(
+        let result = MavenDependencyList::new(
             MavenIdBuf::new("com.google.guava", "guava", "33.6.0-jre"),
             None,
         );
@@ -87,49 +87,49 @@ mod tests {
         let mut dep_list = result.unwrap();
 
         let mut expected = vec![
-            MavenDependancy {
+            MavenDependency {
                 id: MavenIdBuf::new("com.google.guava", "guava", "33.6.0-jre"),
-                dependancy_type: DependancyType::Bundle,
-                dependancies: Vec::new(),
+                dependency_type: DependencyType::Bundle,
+                dependencies: Vec::new(),
                 root: true,
                 scope: Scope::Compile,
             },
-            MavenDependancy {
+            MavenDependency {
                 id: MavenIdBuf::new("com.google.errorprone", "error_prone_annotations", "2.47.0"),
-                dependancy_type: DependancyType::Jar,
-                dependancies: Vec::new(),
+                dependency_type: DependencyType::Jar,
+                dependencies: Vec::new(),
                 root: false,
                 scope: Scope::Compile,
             },
-            MavenDependancy {
+            MavenDependency {
                 id: MavenIdBuf::new("com.google.guava", "failureaccess", "1.0.3"),
-                dependancy_type: DependancyType::Jar,
-                dependancies: Vec::new(),
+                dependency_type: DependencyType::Jar,
+                dependencies: Vec::new(),
                 root: false,
                 scope: Scope::Compile,
             },
-            MavenDependancy {
+            MavenDependency {
                 id: MavenIdBuf::new(
                     "com.google.guava",
                     "listenablefuture",
                     "9999.0-empty-to-avoid-conflict-with-guava",
                 ),
-                dependancy_type: DependancyType::Jar,
-                dependancies: Vec::new(),
+                dependency_type: DependencyType::Jar,
+                dependencies: Vec::new(),
                 root: false,
                 scope: Scope::Compile,
             },
-            MavenDependancy {
+            MavenDependency {
                 id: MavenIdBuf::new("com.google.j2objc", "j2objc-annotations", "3.1"),
-                dependancy_type: DependancyType::Jar,
-                dependancies: Vec::new(),
+                dependency_type: DependencyType::Jar,
+                dependencies: Vec::new(),
                 root: false,
                 scope: Scope::Compile,
             },
-            MavenDependancy {
+            MavenDependency {
                 id: MavenIdBuf::new("org.jspecify", "jspecify", "1.0.0"),
-                dependancy_type: DependancyType::Jar,
-                dependancies: Vec::new(),
+                dependency_type: DependencyType::Jar,
+                dependencies: Vec::new(),
                 root: false,
                 scope: Scope::Compile,
             },
@@ -139,7 +139,7 @@ mod tests {
 
         for (expected, result) in expected.iter().zip(dep_list.iter()) {
             assert!(
-                expected.id == result.id && expected.dependancy_type == result.dependancy_type,
+                expected.id == result.id && expected.dependency_type == result.dependency_type,
                 "Resulting and expected dependences do not match, expected: {:#?}, result: {:#?}",
                 expected,
                 result
@@ -148,9 +148,9 @@ mod tests {
     }
 
     #[test]
-    fn test_maven_dependancy_list_no_duplicates() {
+    fn test_maven_dependency_list_no_duplicates() {
         // Test that the list doesn't have duplicate entries
-        let result = MavenDependancyList::new(
+        let result = MavenDependencyList::new(
             MavenIdBuf::new(
                 "org.springframework.boot",
                 "spring-boot-starter-web",
@@ -183,9 +183,9 @@ mod tests {
     }
 
     #[test]
-    fn test_maven_dependancy_list_versions_valid() {
+    fn test_maven_dependency_list_versions_valid() {
         // Test that all versions in the list are valid version strings
-        let result = MavenDependancyList::new(
+        let result = MavenDependencyList::new(
             MavenIdBuf::new("com.google.guava", "guava", "31.1-jre"),
             None,
         );
@@ -206,9 +206,9 @@ mod tests {
     }
 
     #[test]
-    fn test_maven_dependancy_list_root_artifact_included() {
+    fn test_maven_dependency_list_root_artifact_included() {
         // Test that the root artifact is included in the dependency list
-        let result = MavenDependancyList::new(MavenIdBuf::new("junit", "junit", "4.13.2"), None);
+        let result = MavenDependencyList::new(MavenIdBuf::new("junit", "junit", "4.13.2"), None);
         assert!(result.is_ok());
 
         let dep_list = result.unwrap();
@@ -224,9 +224,9 @@ mod tests {
     }
 
     #[test]
-    fn test_maven_dependancy_list_dependency_types() {
+    fn test_maven_dependency_list_dependency_types() {
         // Test that dependencies have valid packaging types
-        let result = MavenDependancyList::new(
+        let result = MavenDependencyList::new(
             MavenIdBuf::new("com.google.guava", "guava", "31.1-jre"),
             None,
         );
@@ -236,13 +236,13 @@ mod tests {
 
         for dep in &dep_list {
             assert!(
-                dep.dependancy_type == DependancyType::Jar
-                    || dep.dependancy_type == DependancyType::Bundle
-                    || matches!(dep.dependancy_type, DependancyType::Other(_)),
+                dep.dependency_type == DependencyType::Jar
+                    || dep.dependency_type == DependencyType::Bundle
+                    || matches!(dep.dependency_type, DependencyType::Other(_)),
                 "Dependency {}:{} has invalid type: {:?}",
                 dep.id.group,
                 dep.id.artifact,
-                dep.dependancy_type
+                dep.dependency_type
             );
         }
     }

--- a/src/run/execute.rs
+++ b/src/run/execute.rs
@@ -4,10 +4,10 @@ use std::{
 };
 
 use crate::{
-    Context, JAVAC_SEPERATOR,
+    Context, JAVAC_SEPARATOR,
     args::RunArgs,
     build::BuildError,
-    utils::{IOError, SeperatorList, processes::java_tool_command},
+    utils::{IOError, SeparatorList, processes::java_tool_command},
 };
 
 /// Build and run a raw `java` command. `classpath` is emitted only when
@@ -55,7 +55,7 @@ pub fn execute_java(class: &str, args: &RunArgs, ctx: &Context) -> Result<ExitSt
         ))
     })?;
 
-    let classpath = SeperatorList::new(JAVAC_SEPERATOR)
+    let classpath = SeparatorList::new(JAVAC_SEPARATOR)
         .add(ab_bin_processors.display())
         .add(ab_bin.display())
         .add_glob(ab_lib_annotations.display())

--- a/src/run/run_error.rs
+++ b/src/run/run_error.rs
@@ -21,7 +21,7 @@ pub enum RunError {
     #[error("Jar not found at {0}, build the jar first with `lazy-java build jar`")]
     JarNotFound(PathBuf),
 
-    #[error("Build error occured while building before running")]
+    #[error("Build error occurred while building before running")]
     BuildError(#[from] BuildError),
 
     #[error(transparent)]

--- a/src/utils/errors/io_error.rs
+++ b/src/utils/errors/io_error.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 use crate::utils::{Diagnostic, DiagnosticProvider};
 
 #[derive(Error, Debug)]
-#[error("IO error occured while {action} {path}: {source}")]
+#[error("IO error occurred while {action} {path}: {source}")]
 pub struct IOError {
     action: &'static str,
     path: PathBuf,

--- a/src/utils/find_main.rs
+++ b/src/utils/find_main.rs
@@ -192,7 +192,7 @@ mod tests {
 
             assert!(
                 expect.is_some(),
-                "Couldnt Find Expected Main Class Matching a Class Found "
+                "Couldn't find expected main class matching a class found"
             );
             let expect = expect.unwrap();
             let con_main = fs::canonicalize(&main.path)?;

--- a/src/utils/find_root.rs
+++ b/src/utils/find_root.rs
@@ -57,7 +57,7 @@ pub fn find_file_in_dir(dir: &Path, search_name: &str) -> Result<DirEntry, io::E
     }
 
     log::warn!("File not found: {} in {:?}", search_name, dir);
-    Err(io::Error::new(ErrorKind::NotFound, "Couldnt find file"))
+    Err(io::Error::new(ErrorKind::NotFound, "Couldn't find file"))
 }
 
 pub fn list_dir(path: &Path) -> Result<Vec<DirEntry>, io::Error> {
@@ -88,7 +88,7 @@ mod tests {
 
         assert!(
             file3.is_err(),
-            "When finding a file that doesnt exist expected error"
+            "When finding a file that doesn't exist expected error"
         );
 
         return Ok(());

--- a/src/utils/join_dir.rs
+++ b/src/utils/join_dir.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use log::{debug, warn};
 use walkdir::WalkDir;
 
-pub fn join_directory(path: &Path, seperator: char) -> String {
+pub fn join_directory(path: &Path, separator: char) -> String {
     let mut des = String::new();
 
     let mut first = true;
@@ -14,7 +14,7 @@ pub fn join_directory(path: &Path, seperator: char) -> String {
             && let Ok(ab) = path::absolute(f.path()) {
                 if let Some(valid_str) = ab.to_str() {
                     if !first {
-                        des.push(seperator);
+                        des.push(separator);
                     }
                     des.push_str(valid_str);
                     first = false

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,11 +4,11 @@ pub mod fs;
 pub mod jdk_version;
 mod join_dir;
 pub mod processes;
-mod seperator_list;
+mod separator_list;
 pub mod timings;
 
 pub use join_dir::join_directory;
-pub use seperator_list::SeperatorList;
+pub use separator_list::SeparatorList;
 pub use timings::Timings;
 
 mod context;

--- a/src/utils/separator_list.rs
+++ b/src/utils/separator_list.rs
@@ -7,12 +7,12 @@ use std::fmt::Display;
 /// This avoids hand-assembling strings like
 /// `"{dir1}:{dir2}/*:{dir3}/*"` and keeps the trailing `/*` decision next to
 /// each entry.
-pub struct SeperatorList {
+pub struct SeparatorList {
     sep: char,
     entries: Vec<String>,
 }
 
-impl SeperatorList {
+impl SeparatorList {
     pub fn new(sep: char) -> Self {
         Self {
             sep,
@@ -64,16 +64,16 @@ impl SeperatorList {
 
 #[cfg(test)]
 mod tests {
-    use super::SeperatorList;
+    use super::SeparatorList;
 
     #[test]
     fn empty_builds_empty_string() {
-        assert_eq!(SeperatorList::new(':').build(), "");
+        assert_eq!(SeparatorList::new(':').build(), "");
     }
 
     #[test]
-    fn joins_with_seperator() {
-        let list = SeperatorList::new(';')
+    fn joins_with_separator() {
+        let list = SeparatorList::new(';')
             .add("a")
             .add("b")
             .add("c")
@@ -83,7 +83,7 @@ mod tests {
 
     #[test]
     fn supports_glob_suffix_per_entry() {
-        let list = SeperatorList::new(':')
+        let list = SeparatorList::new(':')
             .add("lib")
             .add_glob("jars")
             .add_glob("more")
@@ -93,13 +93,13 @@ mod tests {
 
     #[test]
     fn adds_plain_slice() {
-        let list = SeperatorList::new(';').add_slice(&["a", "b", "c"]).build();
+        let list = SeparatorList::new(';').add_slice(&["a", "b", "c"]).build();
         assert_eq!(list, "a;b;c");
     }
 
     #[test]
     fn adds_glob_slice() {
-        let list = SeperatorList::new(';')
+        let list = SeparatorList::new(';')
             .add_slice_glob(&["a", "b", "c"])
             .build();
         assert_eq!(list, "a/*;b/*;c/*");
@@ -107,7 +107,7 @@ mod tests {
 
     #[test]
     fn mixes_single_and_slice() {
-        let list = SeperatorList::new(':')
+        let list = SeparatorList::new(':')
             .add("base")
             .add_slice_glob(&["a", "b"])
             .build();

--- a/test_filesystem/project/lazy-java.lock
+++ b/test_filesystem/project/lazy-java.lock
@@ -7,7 +7,7 @@ url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-servl
 packaging = "jar"
 root = false
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot"
 version = "4.1.0"
@@ -21,12 +21,12 @@ url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-jacks
 packaging = "jar"
 root = false
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot"
 version = "4.1.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "tools.jackson.core"
 artifact = "jackson-databind"
 version = "3.1.4"
@@ -37,7 +37,7 @@ artifact = "tomcat-embed-websocket"
 version = "11.0.22"
 file_name = "tomcat-embed-websocket-11.0.22.jar"
 url = "https://repo1.maven.org/maven2/org/apache/tomcat/embed/tomcat-embed-websocket/11.0.22/tomcat-embed-websocket-11.0.22.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 
@@ -47,7 +47,7 @@ artifact = "jspecify"
 version = "1.0.0"
 file_name = "jspecify-1.0.0.jar"
 url = "https://repo1.maven.org/maven2/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 
@@ -57,7 +57,7 @@ artifact = "slf4j-api"
 version = "2.0.18"
 file_name = "slf4j-api-2.0.18.jar"
 url = "https://repo1.maven.org/maven2/org/slf4j/slf4j-api/2.0.18/slf4j-api-2.0.18.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 
@@ -70,27 +70,27 @@ url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-start
 packaging = "jar"
 root = false
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.apache.tomcat.embed"
 artifact = "tomcat-embed-websocket"
 version = "11.0.22"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-web-server"
 version = "4.1.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.apache.tomcat.embed"
 artifact = "tomcat-embed-el"
 version = "11.0.22"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "jakarta.annotation"
 artifact = "jakarta.annotation-api"
 version = "3.0.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.apache.tomcat.embed"
 artifact = "tomcat-embed-core"
 version = "11.0.22"
@@ -101,7 +101,7 @@ artifact = "commons-logging"
 version = "1.3.5"
 file_name = "commons-logging-1.3.5.jar"
 url = "https://repo1.maven.org/maven2/commons-logging/commons-logging/1.3.5/commons-logging-1.3.5.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 
@@ -114,17 +114,17 @@ url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-start
 packaging = "jar"
 root = false
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.slf4j"
 artifact = "jul-to-slf4j"
 version = "2.0.18"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "ch.qos.logback"
 artifact = "logback-classic"
 version = "1.5.34"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.apache.logging.log4j"
 artifact = "log4j-to-slf4j"
 version = "2.25.4"
@@ -135,7 +135,7 @@ artifact = "jackson-annotations"
 version = "2.21"
 file_name = "jackson-annotations-2.21.jar"
 url = "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 
@@ -148,17 +148,17 @@ url = "https://repo1.maven.org/maven2/org/springframework/spring-web/7.0.8/sprin
 packaging = "jar"
 root = false
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-beans"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "io.micrometer"
 artifact = "micrometer-observation"
 version = "1.16.6"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-core"
 version = "7.0.8"
@@ -172,7 +172,7 @@ url = "https://repo1.maven.org/maven2/ch/qos/logback/logback-classic/1.5.34/logb
 packaging = "jar"
 root = false
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "ch.qos.logback"
 artifact = "logback-core"
 version = "1.5.34"
@@ -186,7 +186,7 @@ url = "https://repo1.maven.org/maven2/org/slf4j/jul-to-slf4j/2.0.18/jul-to-slf4j
 packaging = "jar"
 root = false
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.slf4j"
 artifact = "slf4j-api"
 version = "2.0.18"
@@ -197,7 +197,7 @@ artifact = "jakarta.annotation-api"
 version = "3.0.0"
 file_name = "jakarta.annotation-api-3.0.0.jar"
 url = "https://repo1.maven.org/maven2/jakarta/annotation/jakarta.annotation-api/3.0.0/jakarta.annotation-api-3.0.0.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 
@@ -210,27 +210,27 @@ url = "https://repo1.maven.org/maven2/org/springframework/spring-webmvc/7.0.8/sp
 packaging = "jar"
 root = false
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-beans"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-aop"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-expression"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-context"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-core"
 version = "7.0.8"
@@ -244,7 +244,7 @@ url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot/4.1.0
 packaging = "jar"
 root = false
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-context"
 version = "7.0.8"
@@ -258,7 +258,7 @@ url = "https://repo1.maven.org/maven2/org/apache/tomcat/embed/tomcat-embed-core/
 packaging = "jar"
 root = false
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.apache.tomcat"
 artifact = "tomcat-annotations-api"
 version = "11.0.22"
@@ -272,17 +272,17 @@ url = "https://repo1.maven.org/maven2/org/springframework/spring-context/7.0.8/s
 packaging = "jar"
 root = false
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-aop"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-beans"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-expression"
 version = "7.0.8"
@@ -296,12 +296,12 @@ url = "https://repo1.maven.org/maven2/tools/jackson/core/jackson-databind/3.1.4/
 packaging = "jar"
 root = false
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "tools.jackson.core"
 artifact = "jackson-core"
 version = "3.1.4"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "com.fasterxml.jackson.core"
 artifact = "jackson-annotations"
 version = "2.21"
@@ -315,22 +315,22 @@ url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-start
 packaging = "jar"
 root = false
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-autoconfigure"
 version = "4.1.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.yaml"
 artifact = "snakeyaml"
 version = "2.6"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "jakarta.annotation"
 artifact = "jakarta.annotation-api"
 version = "3.0.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-starter-logging"
 version = "4.1.0"
@@ -341,7 +341,7 @@ artifact = "spring-expression"
 version = "7.0.8"
 file_name = "spring-expression-7.0.8.jar"
 url = "https://repo1.maven.org/maven2/org/springframework/spring-expression/7.0.8/spring-expression-7.0.8.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 
@@ -354,12 +354,12 @@ url = "https://repo1.maven.org/maven2/io/micrometer/micrometer-observation/1.16.
 packaging = "jar"
 root = false
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.jspecify"
 artifact = "jspecify"
 version = "1.0.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "io.micrometer"
 artifact = "micrometer-commons"
 version = "1.16.6"
@@ -370,7 +370,7 @@ artifact = "log4j-api"
 version = "2.25.4"
 file_name = "log4j-api-2.25.4.jar"
 url = "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.25.4/log4j-api-2.25.4.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 
@@ -383,12 +383,12 @@ url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-start
 packaging = "jar"
 root = false
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-starter"
 version = "4.1.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-jackson"
 version = "4.1.0"
@@ -402,17 +402,17 @@ url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-tomca
 packaging = "jar"
 root = false
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-web-server"
 version = "4.1.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.apache.tomcat.embed"
 artifact = "tomcat-embed-core"
 version = "11.0.22"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "jakarta.annotation"
 artifact = "jakarta.annotation-api"
 version = "3.0.0"
@@ -426,12 +426,12 @@ url = "https://repo1.maven.org/maven2/org/springframework/spring-core/7.0.8/spri
 packaging = "jar"
 root = false
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.jspecify"
 artifact = "jspecify"
 version = "1.0.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "commons-logging"
 artifact = "commons-logging"
 version = "1.3.5"
@@ -445,17 +445,17 @@ url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-webmv
 packaging = "jar"
 root = false
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-servlet"
 version = "4.1.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-web"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-webmvc"
 version = "7.0.8"
@@ -469,22 +469,22 @@ url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-start
 packaging = "jar"
 root = true
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-webmvc"
 version = "4.1.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-http-converter"
 version = "4.1.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-starter-tomcat"
 version = "4.1.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-starter-jackson"
 version = "4.1.0"
@@ -495,7 +495,7 @@ artifact = "spring-boot-web-server"
 version = "4.1.0"
 file_name = "spring-boot-web-server-4.1.0.jar"
 url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-web-server/4.1.0/spring-boot-web-server-4.1.0.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 
@@ -505,7 +505,7 @@ artifact = "tomcat-annotations-api"
 version = "11.0.22"
 file_name = "tomcat-annotations-api-11.0.22.jar"
 url = "https://repo1.maven.org/maven2/org/apache/tomcat/tomcat-annotations-api/11.0.22/tomcat-annotations-api-11.0.22.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 
@@ -515,7 +515,7 @@ artifact = "tomcat-embed-el"
 version = "11.0.22"
 file_name = "tomcat-embed-el-11.0.22.jar"
 url = "https://repo1.maven.org/maven2/org/apache/tomcat/embed/tomcat-embed-el/11.0.22/tomcat-embed-el-11.0.22.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 
@@ -525,7 +525,7 @@ artifact = "spring-beans"
 version = "7.0.8"
 file_name = "spring-beans-7.0.8.jar"
 url = "https://repo1.maven.org/maven2/org/springframework/spring-beans/7.0.8/spring-beans-7.0.8.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 
@@ -535,7 +535,7 @@ artifact = "logback-core"
 version = "1.5.34"
 file_name = "logback-core-1.5.34.jar"
 url = "https://repo1.maven.org/maven2/ch/qos/logback/logback-core/1.5.34/logback-core-1.5.34.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 
@@ -545,7 +545,7 @@ artifact = "snakeyaml"
 version = "2.6"
 file_name = "snakeyaml-2.6.jar"
 url = "https://repo1.maven.org/maven2/org/yaml/snakeyaml/2.6/snakeyaml-2.6.jar"
-dependancies = []
+dependencies = []
 packaging = "bundle"
 root = false
 
@@ -555,7 +555,7 @@ artifact = "jackson-core"
 version = "3.1.4"
 file_name = "jackson-core-3.1.4.jar"
 url = "https://repo1.maven.org/maven2/tools/jackson/core/jackson-core/3.1.4/jackson-core-3.1.4.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 
@@ -565,7 +565,7 @@ artifact = "spring-boot-autoconfigure"
 version = "4.1.0"
 file_name = "spring-boot-autoconfigure-4.1.0.jar"
 url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-autoconfigure/4.1.0/spring-boot-autoconfigure-4.1.0.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 
@@ -578,12 +578,12 @@ url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-http-
 packaging = "jar"
 root = false
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-web"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot"
 version = "4.1.0"
@@ -597,17 +597,17 @@ url = "https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-start
 packaging = "jar"
 root = false
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-tomcat"
 version = "4.1.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-starter-tomcat-runtime"
 version = "4.1.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-starter"
 version = "4.1.0"
@@ -621,7 +621,7 @@ url = "https://repo1.maven.org/maven2/org/springframework/spring-aop/7.0.8/sprin
 packaging = "jar"
 root = false
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-beans"
 version = "7.0.8"
@@ -635,7 +635,7 @@ url = "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-to-slf4j/2.
 packaging = "jar"
 root = false
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.apache.logging.log4j"
 artifact = "log4j-api"
 version = "2.25.4"
@@ -646,6 +646,6 @@ artifact = "micrometer-commons"
 version = "1.16.6"
 file_name = "micrometer-commons-1.16.6.jar"
 url = "https://repo1.maven.org/maven2/io/micrometer/micrometer-commons/1.16.6/micrometer-commons-1.16.6.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false

--- a/test_filesystem/project/lazy-java.toml
+++ b/test_filesystem/project/lazy-java.toml
@@ -4,5 +4,5 @@ name = "hello"
 [resources]
 exclude = ["*.js"]
 
-[dependancies]
+[dependencies]
 spring-boot-starter-web= { group = "org.springframework.boot", version = "4.1.0" }

--- a/test_filesystem/test10/lazy-java.lock
+++ b/test_filesystem/test10/lazy-java.lock
@@ -9,7 +9,7 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "ch.qos.logback"
 artifact = "logback-core"
 version = "1.5.34"
@@ -20,7 +20,7 @@ artifact = "logback-core"
 version = "1.5.34"
 file_name = "logback-core-1.5.34.jar"
 url = "https://repo1.maven.org/maven2/ch/qos/logback/logback-core/1.5.34/logback-core-1.5.34.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 scope = "compile"
@@ -32,7 +32,7 @@ artifact = "jackson-annotations"
 version = "2.21"
 file_name = "jackson-annotations-2.21.jar"
 url = "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 scope = "compile"
@@ -44,7 +44,7 @@ artifact = "auto-value"
 version = "1.11.1"
 file_name = "auto-value-1.11.1.jar"
 url = "https://repo1.maven.org/maven2/com/google/auto/value/auto-value/1.11.1/auto-value-1.11.1.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = true
 scope = "compile"
@@ -56,7 +56,7 @@ artifact = "auto-value-annotations"
 version = "1.11.1"
 file_name = "auto-value-annotations-1.11.1.jar"
 url = "https://repo1.maven.org/maven2/com/google/auto/value/auto-value-annotations/1.11.1/auto-value-annotations-1.11.1.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = true
 scope = "compile"
@@ -68,7 +68,7 @@ artifact = "commons-logging"
 version = "1.3.5"
 file_name = "commons-logging-1.3.5.jar"
 url = "https://repo1.maven.org/maven2/commons-logging/commons-logging/1.3.5/commons-logging-1.3.5.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 scope = "compile"
@@ -85,7 +85,7 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.jspecify"
 artifact = "jspecify"
 version = "1.0.0"
@@ -101,12 +101,12 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "io.micrometer"
 artifact = "micrometer-commons"
 version = "1.16.6"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.jspecify"
 artifact = "jspecify"
 version = "1.0.0"
@@ -117,7 +117,7 @@ artifact = "jakarta.annotation-api"
 version = "3.0.0"
 file_name = "jakarta.annotation-api-3.0.0.jar"
 url = "https://repo1.maven.org/maven2/jakarta/annotation/jakarta.annotation-api/3.0.0/jakarta.annotation-api-3.0.0.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 scope = "compile"
@@ -129,7 +129,7 @@ artifact = "log4j-api"
 version = "2.25.4"
 file_name = "log4j-api-2.25.4.jar"
 url = "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.25.4/log4j-api-2.25.4.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 scope = "compile"
@@ -146,7 +146,7 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.apache.logging.log4j"
 artifact = "log4j-api"
 version = "2.25.4"
@@ -157,7 +157,7 @@ artifact = "tomcat-annotations-api"
 version = "11.0.22"
 file_name = "tomcat-annotations-api-11.0.22.jar"
 url = "https://repo1.maven.org/maven2/org/apache/tomcat/tomcat-annotations-api/11.0.22/tomcat-annotations-api-11.0.22.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 scope = "compile"
@@ -174,7 +174,7 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.apache.tomcat"
 artifact = "tomcat-annotations-api"
 version = "11.0.22"
@@ -185,7 +185,7 @@ artifact = "tomcat-embed-el"
 version = "11.0.22"
 file_name = "tomcat-embed-el-11.0.22.jar"
 url = "https://repo1.maven.org/maven2/org/apache/tomcat/embed/tomcat-embed-el/11.0.22/tomcat-embed-el-11.0.22.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 scope = "compile"
@@ -202,7 +202,7 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.apache.tomcat.embed"
 artifact = "tomcat-embed-core"
 version = "11.0.22"
@@ -213,7 +213,7 @@ artifact = "jspecify"
 version = "1.0.0"
 file_name = "jspecify-1.0.0.jar"
 url = "https://repo1.maven.org/maven2/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 scope = "compile"
@@ -230,7 +230,7 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.slf4j"
 artifact = "slf4j-api"
 version = "2.0.18"
@@ -241,7 +241,7 @@ artifact = "slf4j-api"
 version = "2.0.18"
 file_name = "slf4j-api-2.0.18.jar"
 url = "https://repo1.maven.org/maven2/org/slf4j/slf4j-api/2.0.18/slf4j-api-2.0.18.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 scope = "compile"
@@ -258,12 +258,12 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-beans"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-core"
 version = "7.0.8"
@@ -279,7 +279,7 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-core"
 version = "7.0.8"
@@ -295,27 +295,27 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "io.micrometer"
 artifact = "micrometer-observation"
 version = "1.16.6"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-aop"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-beans"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-core"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-expression"
 version = "7.0.8"
@@ -331,12 +331,12 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "commons-logging"
 artifact = "commons-logging"
 version = "1.3.5"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.jspecify"
 artifact = "jspecify"
 version = "1.0.0"
@@ -352,7 +352,7 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-core"
 version = "7.0.8"
@@ -368,17 +368,17 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "io.micrometer"
 artifact = "micrometer-observation"
 version = "1.16.6"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-beans"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-core"
 version = "7.0.8"
@@ -394,32 +394,32 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-aop"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-beans"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-context"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-core"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-expression"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-web"
 version = "7.0.8"
@@ -435,12 +435,12 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-context"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-core"
 version = "7.0.8"
@@ -456,7 +456,7 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot"
 version = "4.1.0"
@@ -472,12 +472,12 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-web"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot"
 version = "4.1.0"
@@ -493,12 +493,12 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot"
 version = "4.1.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "tools.jackson.core"
 artifact = "jackson-databind"
 version = "3.1.4"
@@ -514,12 +514,12 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-web"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot"
 version = "4.1.0"
@@ -535,22 +535,22 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "jakarta.annotation"
 artifact = "jakarta.annotation-api"
 version = "3.0.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-autoconfigure"
 version = "4.1.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-starter-logging"
 version = "4.1.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.yaml"
 artifact = "snakeyaml"
 version = "2.6"
@@ -566,12 +566,12 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-jackson"
 version = "4.1.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-starter"
 version = "4.1.0"
@@ -587,17 +587,17 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "ch.qos.logback"
 artifact = "logback-classic"
 version = "1.5.34"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.apache.logging.log4j"
 artifact = "log4j-to-slf4j"
 version = "2.25.4"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.slf4j"
 artifact = "jul-to-slf4j"
 version = "2.0.18"
@@ -613,17 +613,17 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-starter"
 version = "4.1.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-starter-tomcat-runtime"
 version = "4.1.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-tomcat"
 version = "4.1.0"
@@ -639,32 +639,32 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "jakarta.annotation"
 artifact = "jakarta.annotation-api"
 version = "3.0.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.apache.tomcat.embed"
 artifact = "tomcat-embed-core"
 version = "11.0.22"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.apache.tomcat.embed"
 artifact = "tomcat-embed-el"
 version = "11.0.22"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.apache.tomcat.embed"
 artifact = "tomcat-embed-websocket"
 version = "11.0.22"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-tomcat"
 version = "4.1.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-web-server"
 version = "4.1.0"
@@ -680,22 +680,22 @@ root = true
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-http-converter"
 version = "4.1.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-starter-jackson"
 version = "4.1.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-starter-tomcat"
 version = "4.1.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-webmvc"
 version = "4.1.0"
@@ -711,17 +711,17 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "jakarta.annotation"
 artifact = "jakarta.annotation-api"
 version = "3.0.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.apache.tomcat.embed"
 artifact = "tomcat-embed-core"
 version = "11.0.22"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-web-server"
 version = "4.1.0"
@@ -737,12 +737,12 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-web"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot"
 version = "4.1.0"
@@ -758,22 +758,22 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-web"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-webmvc"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-http-converter"
 version = "4.1.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-servlet"
 version = "4.1.0"
@@ -784,7 +784,7 @@ artifact = "snakeyaml"
 version = "2.6"
 file_name = "snakeyaml-2.6.jar"
 url = "https://repo1.maven.org/maven2/org/yaml/snakeyaml/2.6/snakeyaml-2.6.jar"
-dependancies = []
+dependencies = []
 packaging = "bundle"
 root = false
 scope = "compile"
@@ -796,7 +796,7 @@ artifact = "jackson-core"
 version = "3.1.4"
 file_name = "jackson-core-3.1.4.jar"
 url = "https://repo1.maven.org/maven2/tools/jackson/core/jackson-core/3.1.4/jackson-core-3.1.4.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 scope = "compile"
@@ -813,12 +813,12 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "com.fasterxml.jackson.core"
 artifact = "jackson-annotations"
 version = "2.21"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "tools.jackson.core"
 artifact = "jackson-core"
 version = "3.1.4"

--- a/test_filesystem/test10/lazy-java.toml
+++ b/test_filesystem/test10/lazy-java.toml
@@ -17,7 +17,7 @@ kind = "processor"
 path = "./src/processor/ProcessorImpl.java"
 package = "processor"
 
-[dependancies]
+[dependencies]
 spring-boot-starter-web= { group = "org.springframework.boot", version = "4.1.0" }
 auto-value-annotations= { group = "com.google.auto.value", version = "1.11.1" }
 auto-value= { group = "com.google.auto.value", version = "1.11.1" }

--- a/tests/fixtures/local-annot-runtime/lazy-java.toml
+++ b/tests/fixtures/local-annot-runtime/lazy-java.toml
@@ -1,5 +1,5 @@
 [project]
 name = "local-annot-runtime"
 
-[dependancies]
+[dependencies]
 myannot = { path = "./lib/myannot.jar" }

--- a/tests/suite/group44_test.rs
+++ b/tests/suite/group44_test.rs
@@ -67,7 +67,7 @@ fn normalize_output(output: &str, root: &Path) -> String {
 }
 
 #[test]
-fn group44_full_build_graph_and_incrimental_snapshots() -> Result<(), Box<dyn std::error::Error>> {
+fn group44_full_build_graph_and_incremental_snapshots() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = copy_fixture();
     let dest = tmp.path().join("project");
 
@@ -77,14 +77,14 @@ fn group44_full_build_graph_and_incrimental_snapshots() -> Result<(), Box<dyn st
         normalize_output(&run(&dest, &["build", "--show-compiled"])?, &dest)
     );
 
-    // Dependency and dependant graphs
+    // Dependency and dependents graphs
     insta::assert_snapshot!(
-        "dependancy_graph",
-        normalize_output(&run(&dest, &["build", "dependancies"])?, &dest)
+        "dependency_graph",
+        normalize_output(&run(&dest, &["build", "dependencies"])?, &dest)
     );
     insta::assert_snapshot!(
-        "dependants_graph",
-        normalize_output(&run(&dest, &["build", "dependants"])?, &dest)
+        "dependents_graph",
+        normalize_output(&run(&dest, &["build", "dependents"])?, &dest)
     );
 
     // Nothing should be stale right after a build
@@ -95,7 +95,7 @@ fn group44_full_build_graph_and_incrimental_snapshots() -> Result<(), Box<dyn st
 
     // Edit a low-level utility that is imported across the whole UI,
     // expecting the incremental build to fan out to every transitive
-    // dependant.
+    // dependents.
     let color_manager = dest.join("src/utils/ColorManager.java");
     let mut contents = std::fs::read_to_string(&color_manager)?;
     contents.push_str("\n    // modified by the group44 e2e test\n");
@@ -107,21 +107,21 @@ fn group44_full_build_graph_and_incrimental_snapshots() -> Result<(), Box<dyn st
     );
 
     // The incremental build must recompile the edited file plus all its
-    // transitive dependants, and still succeed.
+    // transitive dependents, and still succeed.
     insta::assert_snapshot!(
-        "incrimental_build_after_color_manager_edit",
+        "incremental_build_after_color_manager_edit",
         normalize_output(&run(&dest, &["build", "--show-compiled"])?, &dest)
     );
 
     // After the incremental build nothing should be stale.
     insta::assert_snapshot!(
-        "stale_after_incrimental_build",
+        "stale_after_incremental_build",
         normalize_output(&run(&dest, &["build", "stale"])?, &dest)
     );
 
     // A repeated build with no further changes skips compilation entirely.
     insta::assert_snapshot!(
-        "incrimental_build_no_changes",
+        "incremental_build_no_changes",
         normalize_output(&run(&dest, &["build"])?, &dest)
     );
 

--- a/tests/suite/incremental_build_test.rs
+++ b/tests/suite/incremental_build_test.rs
@@ -93,7 +93,7 @@ public class Calc {
 "#;
 
 #[test]
-fn incremental_build_dependancy_and_subcommand_snapshots() -> Result<(), Box<dyn std::error::Error>>
+fn incremental_build_dependency_and_subcommand_snapshots() -> Result<(), Box<dyn std::error::Error>>
 {
     let tmp = copy_fixture();
     let dest = tmp.path().join("project");
@@ -104,14 +104,14 @@ fn incremental_build_dependancy_and_subcommand_snapshots() -> Result<(), Box<dyn
         normalize_output(&run(&dest, &["build", "--show-compiled"])?, &dest)
     );
 
-    // Dependency and dependant graphs
+    // Dependency and dependents graphs
     insta::assert_snapshot!(
-        "dependancy_graph",
-        normalize_output(&run(&dest, &["build", "dependancies"])?, &dest)
+        "dependency_graph",
+        normalize_output(&run(&dest, &["build", "dependencies"])?, &dest)
     );
     insta::assert_snapshot!(
-        "dependants_graph",
-        normalize_output(&run(&dest, &["build", "dependants"])?, &dest)
+        "dependents_graph",
+        normalize_output(&run(&dest, &["build", "dependents"])?, &dest)
     );
 
     // Nothing should be stale right after a build
@@ -120,7 +120,7 @@ fn incremental_build_dependancy_and_subcommand_snapshots() -> Result<(), Box<dyn
         normalize_output(&run(&dest, &["build", "stale"])?, &dest)
     );
 
-    // Editing a leaf file (no dependants of its own) fans out to all transitive dependants
+    // Editing a leaf file (no dependents of its own) fans out to all transitive dependents
     std::fs::write(dest.join("src/greeting/Formatter.java"), MODIFIED_FORMATTER)?;
 
     insta::assert_snapshot!(
@@ -128,19 +128,19 @@ fn incremental_build_dependancy_and_subcommand_snapshots() -> Result<(), Box<dyn
         normalize_output(&run(&dest, &["build", "stale"])?, &dest)
     );
 
-    // Incremental build recompiles the file plus its transitive dependants
+    // Incremental build recompiles the file plus its transitive dependents
     insta::assert_snapshot!(
-        "incrimental_build_after_leaf_edit",
+        "incremental_build_after_leaf_edit",
         normalize_output(&run(&dest, &["build", "--show-compiled"])?, &dest)
     );
 
     // A second build with no changes skips compilation entirely
     insta::assert_snapshot!(
-        "incrimental_build_no_changes",
+        "incremental_build_no_changes",
         normalize_output(&run(&dest, &["build"])?, &dest)
     );
 
-    // Editing a mid-graph file fans out to its same-package files and dependants
+    // Editing a mid-graph file fans out to its same-package files and dependents
     std::fs::write(dest.join("src/math/Calc.java"), MODIFIED_CALC)?;
 
     insta::assert_snapshot!(
@@ -148,7 +148,7 @@ fn incremental_build_dependancy_and_subcommand_snapshots() -> Result<(), Box<dyn
         normalize_output(&run(&dest, &["build", "stale"])?, &dest)
     );
     insta::assert_snapshot!(
-        "incrimental_build_after_mid_edit",
+        "incremental_build_after_mid_edit",
         normalize_output(&run(&dest, &["build"])?, &dest)
     );
 

--- a/tests/suite/local_annot_runtime_test.rs
+++ b/tests/suite/local_annot_runtime_test.rs
@@ -62,7 +62,7 @@ fn walkdir(dir: &Path, ext: &str) -> Result<Vec<String>, Box<dyn std::error::Err
         let path = entry.path();
         if path.is_dir() {
             out.extend(walkdir(&path, ext)?);
-        } else if path.extension().map_or(false, |e| e == ext) {
+        } else if path.extension().is_some_and(|e| e == ext) {
             out.push(path.to_string_lossy().to_string());
         }
     }

--- a/tests/suite/snapshots/all__suite__group44_test__dependency_graph.snap
+++ b/tests/suite/snapshots/all__suite__group44_test__dependency_graph.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/suite/group44_test.rs
-expression: "normalize_output(&run(&dest, &[\"build\", \"dependancies\"])?, &dest)"
+expression: "normalize_output(&run(&dest, &[\"build\", \"dependencies\"])?, &dest)"
 ---
     Validating lib
     Validating lib-annotations
@@ -627,7 +627,7 @@ ClientState.java (state/clientState/ClientState.java)
 ColorManager.java (utils/ColorManager.java)
 Controller.java (controller/Controller.java)
 CreateAccountPage.java (parentalControls/CreateAccountPage.java)
-Dependancy graph
+Dependency graph
 DisconnectEvent.java (state/clientState/events/DisconnectEvent.java)
 EchoServer.java (eventSystem/engine/EchoServer.java)
 Event.java (eventSystem/events/Event.java)
@@ -700,7 +700,7 @@ StandaloneEvent.java (eventSystem/events/StandaloneEvent.java)
 Stats.java (saveData/Stats.java)
 StyledButton.java (UIComponents/StyledButton.java)
 Subheader.java (UIComponents/Subheader.java)
-Syncing dependancies
+Syncing dependencies
 TeacherControlsPage.java (parentalControls/TeacherControlsPage.java)
 Text.java (UIComponents/Text.java)
 TraceableRawEvent.java (eventSystem/networking/server/TraceableRawEvent.java)

--- a/tests/suite/snapshots/all__suite__group44_test__dependents_graph.snap
+++ b/tests/suite/snapshots/all__suite__group44_test__dependents_graph.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/suite/group44_test.rs
-expression: "normalize_output(&run(&dest, &[\"build\", \"dependants\"])?, &dest)"
+expression: "normalize_output(&run(&dest, &[\"build\", \"dependents\"])?, &dest)"
 ---
     Validating lib
     Validating lib-annotations
@@ -626,7 +626,7 @@ ClientState.java (state/clientState/ClientState.java)
 ColorManager.java (utils/ColorManager.java)
 Controller.java (controller/Controller.java)
 CreateAccountPage.java (parentalControls/CreateAccountPage.java)
-Dependants graph
+Dependents graph
 DisconnectEvent.java (state/clientState/events/DisconnectEvent.java)
 EchoServer.java (eventSystem/engine/EchoServer.java)
 Event.java (eventSystem/events/Event.java)
@@ -699,7 +699,7 @@ StandaloneEvent.java (eventSystem/events/StandaloneEvent.java)
 Stats.java (saveData/Stats.java)
 StyledButton.java (UIComponents/StyledButton.java)
 Subheader.java (UIComponents/Subheader.java)
-Syncing dependancies
+Syncing dependencies
 TeacherControlsPage.java (parentalControls/TeacherControlsPage.java)
 Text.java (UIComponents/Text.java)
 TraceableRawEvent.java (eventSystem/networking/server/TraceableRawEvent.java)

--- a/tests/suite/snapshots/all__suite__group44_test__full_build_output.snap
+++ b/tests/suite/snapshots/all__suite__group44_test__full_build_output.snap
@@ -101,4 +101,4 @@ Creating build directory: <ROOT>/target/bin
 Creating build processor directory: <ROOT>/target/processor-bin
 Creating generated src directory: <ROOT>/target/generated-source
 Creating library directory: <ROOT>/target/lib
-Syncing dependancies
+Syncing dependencies

--- a/tests/suite/snapshots/all__suite__group44_test__incremental_build_after_color_manager_edit.snap
+++ b/tests/suite/snapshots/all__suite__group44_test__incremental_build_after_color_manager_edit.snap
@@ -73,5 +73,5 @@ expression: "normalize_output(&run(&dest, &[\"build\", \"--show-compiled\"])?, &
   <ROOT>/src/utils/FontManager.java
   <ROOT>/src/utils/Tuple.java
 Compiled in <TIME>s
-Compiling using incrimental build (68 stale files)
-Syncing dependancies
+Compiling using incremental build (68 stale files)
+Syncing dependencies

--- a/tests/suite/snapshots/all__suite__group44_test__incremental_build_no_changes.snap
+++ b/tests/suite/snapshots/all__suite__group44_test__incremental_build_no_changes.snap
@@ -1,9 +1,9 @@
 ---
-source: tests/suite/incremental_build_test.rs
+source: tests/suite/group44_test.rs
 expression: "normalize_output(&run(&dest, &[\"build\"])?, &dest)"
 ---
     Validating lib
     Validating lib-annotations
 Compiled in <TIME>s
-Compiling using incrimental build (0 stale files)
-Syncing dependancies
+Compiling using incremental build (0 stale files)
+Syncing dependencies

--- a/tests/suite/snapshots/all__suite__group44_test__stale_after_color_manager_edit.snap
+++ b/tests/suite/snapshots/all__suite__group44_test__stale_after_color_manager_edit.snap
@@ -73,4 +73,4 @@ expression: "normalize_output(&run(&dest, &[\"build\", \"stale\"])?, &dest)"
   <ROOT>/src/utils/FontManager.java
   <ROOT>/src/utils/Tuple.java
 Stale 68 files to recompile
-Syncing dependancies
+Syncing dependencies

--- a/tests/suite/snapshots/all__suite__group44_test__stale_after_full_build.snap
+++ b/tests/suite/snapshots/all__suite__group44_test__stale_after_full_build.snap
@@ -5,4 +5,4 @@ expression: "normalize_output(&run(&dest, &[\"build\", \"stale\"])?, &dest)"
     Validating lib
     Validating lib-annotations
 Stale 0 files to recompile
-Syncing dependancies
+Syncing dependencies

--- a/tests/suite/snapshots/all__suite__group44_test__stale_after_incremental_build.snap
+++ b/tests/suite/snapshots/all__suite__group44_test__stale_after_incremental_build.snap
@@ -5,4 +5,4 @@ expression: "normalize_output(&run(&dest, &[\"build\", \"stale\"])?, &dest)"
     Validating lib
     Validating lib-annotations
 Stale 0 files to recompile
-Syncing dependancies
+Syncing dependencies

--- a/tests/suite/snapshots/all__suite__import_pom_test__import_pom_output.snap
+++ b/tests/suite/snapshots/all__suite__import_pom_test__import_pom_output.snap
@@ -3,7 +3,7 @@ source: tests/suite/import_pom_test.rs
 assertion_line: 32
 expression: toml_content
 ---
-[dependancies]
+[dependencies]
 commons-lang3 = { group = "org.apache.commons", version = "3.12.0", scope = "compile" }
 guava = { group = "com.google.guava", version = "33.0.0-jre", scope = "compile" }
 

--- a/tests/suite/snapshots/all__suite__incremental_build_test__dependency_graph.snap
+++ b/tests/suite/snapshots/all__suite__incremental_build_test__dependency_graph.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/suite/incremental_build_test.rs
-expression: "normalize_output(&run(&dest, &[\"build\", \"dependancies\"])?, &dest)"
+expression: "normalize_output(&run(&dest, &[\"build\", \"dependencies\"])?, &dest)"
 ---
     Validating lib
     Validating lib-annotations
@@ -17,11 +17,11 @@ expression: "normalize_output(&run(&dest, &[\"build\", \"dependancies\"])?, &des
   - Subtracter.java (math/Subtracter.java)
 Adder.java (math/Adder.java)
 Calc.java (math/Calc.java)
-Dependancy graph
+Dependency graph
 Formatter.java (greeting/Formatter.java)
 Greeter.java (lib/Greeter.java)
 Main.java (Main.java)
 Painter.java (ui/Painter.java)
 Strings.java (util/Strings.java)
 Subtracter.java (math/Subtracter.java)
-Syncing dependancies
+Syncing dependencies

--- a/tests/suite/snapshots/all__suite__incremental_build_test__dependents_graph.snap
+++ b/tests/suite/snapshots/all__suite__incremental_build_test__dependents_graph.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/suite/incremental_build_test.rs
-expression: "normalize_output(&run(&dest, &[\"build\", \"dependants\"])?, &dest)"
+expression: "normalize_output(&run(&dest, &[\"build\", \"dependents\"])?, &dest)"
 ---
     Validating lib
     Validating lib-annotations
@@ -17,8 +17,8 @@ expression: "normalize_output(&run(&dest, &[\"build\", \"dependants\"])?, &dest)
   - Subtracter.java (math/Subtracter.java)
 Adder.java (math/Adder.java)
 Calc.java (math/Calc.java)
-Dependants graph
+Dependents graph
 Formatter.java (greeting/Formatter.java)
 Greeter.java (lib/Greeter.java)
 Subtracter.java (math/Subtracter.java)
-Syncing dependancies
+Syncing dependencies

--- a/tests/suite/snapshots/all__suite__incremental_build_test__full_build_output.snap
+++ b/tests/suite/snapshots/all__suite__incremental_build_test__full_build_output.snap
@@ -19,4 +19,4 @@ Creating build directory: <ROOT>/target/bin
 Creating build processor directory: <ROOT>/target/processor-bin
 Creating generated src directory: <ROOT>/target/generated-source
 Creating library directory: <ROOT>/target/lib
-Syncing dependancies
+Syncing dependencies

--- a/tests/suite/snapshots/all__suite__incremental_build_test__incremental_build_after_leaf_edit.snap
+++ b/tests/suite/snapshots/all__suite__incremental_build_test__incremental_build_after_leaf_edit.snap
@@ -4,6 +4,10 @@ expression: "normalize_output(&run(&dest, &[\"build\"])?, &dest)"
 ---
     Validating lib
     Validating lib-annotations
+  <ROOT>/src/Main.java
+  <ROOT>/src/greeting/Formatter.java
+  <ROOT>/src/lib/Greeter.java
+  <ROOT>/src/ui/Painter.java
 Compiled in <TIME>s
-Compiling using incrimental build (4 stale files)
-Syncing dependancies
+Compiling using incremental build (4 stale files)
+Syncing dependencies

--- a/tests/suite/snapshots/all__suite__incremental_build_test__incremental_build_after_mid_edit.snap
+++ b/tests/suite/snapshots/all__suite__incremental_build_test__incremental_build_after_mid_edit.snap
@@ -4,10 +4,6 @@ expression: "normalize_output(&run(&dest, &[\"build\"])?, &dest)"
 ---
     Validating lib
     Validating lib-annotations
-  <ROOT>/src/Main.java
-  <ROOT>/src/greeting/Formatter.java
-  <ROOT>/src/lib/Greeter.java
-  <ROOT>/src/ui/Painter.java
 Compiled in <TIME>s
-Compiling using incrimental build (4 stale files)
-Syncing dependancies
+Compiling using incremental build (4 stale files)
+Syncing dependencies

--- a/tests/suite/snapshots/all__suite__incremental_build_test__incremental_build_no_changes.snap
+++ b/tests/suite/snapshots/all__suite__incremental_build_test__incremental_build_no_changes.snap
@@ -1,9 +1,9 @@
 ---
-source: tests/suite/group44_test.rs
+source: tests/suite/incremental_build_test.rs
 expression: "normalize_output(&run(&dest, &[\"build\"])?, &dest)"
 ---
     Validating lib
     Validating lib-annotations
 Compiled in <TIME>s
-Compiling using incrimental build (0 stale files)
-Syncing dependancies
+Compiling using incremental build (0 stale files)
+Syncing dependencies

--- a/tests/suite/snapshots/all__suite__incremental_build_test__stale_after_full_build.snap
+++ b/tests/suite/snapshots/all__suite__incremental_build_test__stale_after_full_build.snap
@@ -5,4 +5,4 @@ expression: "normalize_output(&run(&dest, &[\"build\", \"stale\"])?, &dest)"
     Validating lib
     Validating lib-annotations
 Stale 0 files to recompile
-Syncing dependancies
+Syncing dependencies

--- a/tests/suite/snapshots/all__suite__incremental_build_test__stale_after_leaf_edit.snap
+++ b/tests/suite/snapshots/all__suite__incremental_build_test__stale_after_leaf_edit.snap
@@ -9,4 +9,4 @@ expression: "normalize_output(&run(&dest, &[\"build\", \"stale\"])?, &dest)"
   <ROOT>/src/lib/Greeter.java
   <ROOT>/src/ui/Painter.java
 Stale 4 files to recompile
-Syncing dependancies
+Syncing dependencies

--- a/tests/suite/snapshots/all__suite__incremental_build_test__stale_after_mid_edit.snap
+++ b/tests/suite/snapshots/all__suite__incremental_build_test__stale_after_mid_edit.snap
@@ -9,4 +9,4 @@ expression: "normalize_output(&run(&dest, &[\"build\", \"stale\"])?, &dest)"
   <ROOT>/src/math/Calc.java
   <ROOT>/src/math/Subtracter.java
 Stale 4 files to recompile
-Syncing dependancies
+Syncing dependencies

--- a/tests/suite/snapshots/all__suite__remove_dependency_test__add_dependency_config.snap
+++ b/tests/suite/snapshots/all__suite__remove_dependency_test__add_dependency_config.snap
@@ -5,5 +5,5 @@ expression: toml_after_add
 [project]
 name = "with-dependency"
 
-[dependancies]
+[dependencies]
 spring-boot-starter-jdbc = { version = "4.1.0", group = "org.springframework.boot" }

--- a/tests/suite/snapshots/all__suite__remove_dependency_test__add_dependency_lock.snap
+++ b/tests/suite/snapshots/all__suite__remove_dependency_test__add_dependency_lock.snap
@@ -13,7 +13,7 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "ch.qos.logback"
 artifact = "logback-core"
 version = "1.5.34"
@@ -24,7 +24,7 @@ artifact = "logback-core"
 version = "1.5.34"
 file_name = "logback-core-1.5.34.jar"
 url = "https://repo1.maven.org/maven2/ch/qos/logback/logback-core/1.5.34/logback-core-1.5.34.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 scope = "compile"
@@ -36,7 +36,7 @@ artifact = "HikariCP"
 version = "7.0.2"
 file_name = "HikariCP-7.0.2.jar"
 url = "https://repo1.maven.org/maven2/com/zaxxer/HikariCP/7.0.2/HikariCP-7.0.2.jar"
-dependancies = []
+dependencies = []
 packaging = "bundle"
 root = false
 scope = "compile"
@@ -48,7 +48,7 @@ artifact = "commons-logging"
 version = "1.3.5"
 file_name = "commons-logging-1.3.5.jar"
 url = "https://repo1.maven.org/maven2/commons-logging/commons-logging/1.3.5/commons-logging-1.3.5.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 scope = "compile"
@@ -65,7 +65,7 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.jspecify"
 artifact = "jspecify"
 version = "1.0.0"
@@ -81,12 +81,12 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "io.micrometer"
 artifact = "micrometer-commons"
 version = "1.16.6"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.jspecify"
 artifact = "jspecify"
 version = "1.0.0"
@@ -97,7 +97,7 @@ artifact = "jakarta.annotation-api"
 version = "3.0.0"
 file_name = "jakarta.annotation-api-3.0.0.jar"
 url = "https://repo1.maven.org/maven2/jakarta/annotation/jakarta.annotation-api/3.0.0/jakarta.annotation-api-3.0.0.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 scope = "compile"
@@ -114,12 +114,12 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.jspecify"
 artifact = "jspecify"
 version = "1.0.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.osgi"
 artifact = "org.osgi.core"
 version = "6.0.0"
@@ -135,17 +135,17 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.apache.logging.log4j"
 artifact = "log4j-api"
 version = "2.25.4"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.jspecify"
 artifact = "jspecify"
 version = "1.0.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.osgi"
 artifact = "org.osgi.core"
 version = "6.0.0"
@@ -156,7 +156,7 @@ artifact = "jspecify"
 version = "1.0.0"
 file_name = "jspecify-1.0.0.jar"
 url = "https://repo1.maven.org/maven2/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 scope = "compile"
@@ -168,7 +168,7 @@ artifact = "org.osgi.core"
 version = "6.0.0"
 file_name = "org.osgi.core-6.0.0.jar"
 url = "https://repo1.maven.org/maven2/org/osgi/org.osgi.core/6.0.0/org.osgi.core-6.0.0.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 scope = "compile"
@@ -185,7 +185,7 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.slf4j"
 artifact = "slf4j-api"
 version = "2.0.18"
@@ -196,7 +196,7 @@ artifact = "slf4j-api"
 version = "2.0.18"
 file_name = "slf4j-api-2.0.18.jar"
 url = "https://repo1.maven.org/maven2/org/slf4j/slf4j-api/2.0.18/slf4j-api-2.0.18.jar"
-dependancies = []
+dependencies = []
 packaging = "jar"
 root = false
 scope = "compile"
@@ -213,12 +213,12 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-beans"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-core"
 version = "7.0.8"
@@ -234,7 +234,7 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-core"
 version = "7.0.8"
@@ -250,27 +250,27 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "io.micrometer"
 artifact = "micrometer-observation"
 version = "1.16.6"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-aop"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-beans"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-core"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-expression"
 version = "7.0.8"
@@ -286,12 +286,12 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "commons-logging"
 artifact = "commons-logging"
 version = "1.3.5"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.jspecify"
 artifact = "jspecify"
 version = "1.0.0"
@@ -307,7 +307,7 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-core"
 version = "7.0.8"
@@ -323,17 +323,17 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-beans"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-core"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-tx"
 version = "7.0.8"
@@ -349,12 +349,12 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-beans"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-core"
 version = "7.0.8"
@@ -370,12 +370,12 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-context"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-core"
 version = "7.0.8"
@@ -391,7 +391,7 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot"
 version = "4.1.0"
@@ -407,22 +407,22 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-jdbc"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot"
 version = "4.1.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-sql"
 version = "4.1.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-transaction"
 version = "4.1.0"
@@ -438,12 +438,12 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-tx"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot"
 version = "4.1.0"
@@ -459,7 +459,7 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot"
 version = "4.1.0"
@@ -475,22 +475,22 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "jakarta.annotation"
 artifact = "jakarta.annotation-api"
 version = "3.0.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-autoconfigure"
 version = "4.1.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-starter-logging"
 version = "4.1.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.yaml"
 artifact = "snakeyaml"
 version = "2.6"
@@ -506,17 +506,17 @@ root = true
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "com.zaxxer"
 artifact = "HikariCP"
 version = "7.0.2"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-jdbc"
 version = "4.1.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-starter"
 version = "4.1.0"
@@ -532,17 +532,17 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "ch.qos.logback"
 artifact = "logback-classic"
 version = "1.5.34"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.apache.logging.log4j"
 artifact = "log4j-to-slf4j"
 version = "2.25.4"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.slf4j"
 artifact = "jul-to-slf4j"
 version = "2.0.18"
@@ -558,17 +558,17 @@ root = false
 scope = "compile"
 annotations = []
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework"
 artifact = "spring-tx"
 version = "7.0.8"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot"
 version = "4.1.0"
 
-[[package.dependancies]]
+[[package.dependencies]]
 group = "org.springframework.boot"
 artifact = "spring-boot-persistence"
 version = "4.1.0"
@@ -579,7 +579,7 @@ artifact = "snakeyaml"
 version = "2.6"
 file_name = "snakeyaml-2.6.jar"
 url = "https://repo1.maven.org/maven2/org/yaml/snakeyaml/2.6/snakeyaml-2.6.jar"
-dependancies = []
+dependencies = []
 packaging = "bundle"
 root = false
 scope = "compile"

--- a/tests/suite/snapshots/all__suite__remove_dependency_test__remove_dependency_config.snap
+++ b/tests/suite/snapshots/all__suite__remove_dependency_test__remove_dependency_config.snap
@@ -5,4 +5,4 @@ expression: toml_after_remove
 [project]
 name = "with-dependency"
 
-[dependancies]
+[dependencies]


### PR DESCRIPTION
Closes #73

## Summary

Find-and-fix pass for spelling/typo errors across the codebase, plus automated spell-checking in CI so new typos are caught going forward.

## Changes

### Spelling fixes (issue #73)
Fixed typos in user-visible output, error messages, docstrings/comments, and identifiers:

- **User-visible strings**: `occured` → `occurred`, `attemping` → `attempting`, `Couldnt`/`doesnt` → `Couldn't`/`doesn't`, `Initalize` → `Initialize`, `"Incrimental prcoessing"` → `"Incremental processing"`, `Dependancy/Dependants graph` → `Dependency/Dependents graph`, `backwords` → `backwards`.
- **Breaking (format/CLI changes):**
  - Serialized config/lock key `dependancies` → `dependencies` (config section `[dependencies]`, `[[package]]` lock fields), updated fixtures + snapshots.
  - CLI build subcommands `build dependancies` → `build dependencies`, `build dependants` → `build dependents`.
  - `ConfigDependancy` → `ConfigDependency`.
  - Maven POM types: `MavenDependancy(ies)` → `MavenDependency(ies)`, `DependancyList` → `DependencyList`, `DependancyType` → `DependencyType`.
  - Module/file renames: `dependancy_list.rs` → `dependency_list.rs`, `dependancy_list_structs.rs` → `dependency_list_structs.rs`, `seperator_list.rs` → `separator_list.rs`, `SeperatorList`/`JAVAC_SEPERATOR` → `Separator`.
  - `incrimental` → `incremental` in build output + test/snapshot names; `Processer` → `Processor` type identifiers; `CouldntFindMains` → `CouldNotFindMains`.

### Spell-check CI
- `.github/workflows/spell-check.yml`: new `spell-check` job (parallel to build/test) that runs `codespell` and **fails** the build on any typo.
- `codespell.toml`: skips the third-party `tests/fixtures/group44/**` fixture; ignores the legit tokens `ser` and `errorprone` (real Maven artifact name).
- `scripts/spell-check.sh`: local wrapper: `./scripts/spell-check.sh` (requires `codespell`, e.g. `brew install codespell`).

### Notes / intentional exclusions
- Left `com.google.errorprone` (real artifact name).
- `tests/fixtures/group44/` Java sources intentionally untouched — it's a separate fixture project whose identifiers/strings contain deliberate typos as test data.
- `dependancies` fixes are **breaking** for existing projects: old `[dependancies]` configs no longer parse (Struct has `deny_unknown_fields`), and the two build subcommands are renamed.

### Verified
- `cargo build`, `cargo clippy` (CI's disallowed-methods/types gate), `cargo test` — 84 lib + 24 e2e tests pass.
- `codespell --toml codespell.toml src tests` passes and exits non-zero when a typo is introduced.
